### PR TITLE
Fix install instructions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
                 "@typescript-eslint/parser": "5.58.0",
                 "@vitejs/plugin-react": "3.1.0",
                 "@vscode/test-electron": "2.3.0",
+                "cross-env": "^7.0.3",
                 "eslint": "8.38.0",
                 "glob": "10.1.0",
                 "less": "4.1.3",
@@ -1954,6 +1955,24 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+        },
+        "node_modules/cross-env": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+            "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.1"
+            },
+            "bin": {
+                "cross-env": "src/bin/cross-env.js",
+                "cross-env-shell": "src/bin/cross-env-shell.js"
+            },
+            "engines": {
+                "node": ">=10.14",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     },
     "scripts": {
         "SHELL": "",
-            "vscode:dev":        "code --extensionDevelopmentPath=${PWD}",
+            "vscode:dev":        "cross-env-shell code --extensionDevelopmentPath=${PWD}",
         "BACK": "",
             "back:dev":          "npm run back:build -- --sourcemap --watch",
             "back:sourcemap":    "npm run back:build -- --sourcemap",
@@ -151,6 +151,7 @@
         "@typescript-eslint/parser": "5.58.0",
         "@vitejs/plugin-react": "3.1.0",
         "@vscode/test-electron": "2.3.0",
+        "cross-env": "^7.0.3",
         "eslint": "8.38.0",
         "glob": "10.1.0",
         "less": "4.1.3",

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ and guidance along generation processes. It is cross-platform and open-source.
 3. install `CushyStudio` (later: will be in the vscode marketplace)
 
     ```sh
-    git clone github.com/rvion/CushyStudio
+    git clone https://github.com/rvion/CushyStudio.git
     cd CushyStudio
     npm install
 


### PR DESCRIPTION
 - The `git clone` command didn't work with the provided argument
 - `npm run vscode:dev` wasn't working on windows since `${PWD}` wouldn't be resolved → added `cross-env` as a dev package to allow the use of env variables in a cross-platform way