### PR TITLE
Fix bad usage of form-data

### DIFF
--- a/src/core-back/FlowRun.ts
+++ b/src/core-back/FlowRun.ts
@@ -141,13 +141,14 @@ export class FlowRun implements IFlowExecution {
 
     uploadURL = async (url: string = RANDOM_IMAGE_URL): Promise<ComfyUploadImageResult> => {
         const blob = await this.workspace.getUrlAsBlob(url)
-        return this.uploadUIntArrToComfy(blob)
+        const bytes = new Uint8Array(await blob.arrayBuffer())
+        return this.uploadUIntArrToComfy(bytes)
     }
 
-    private uploadUIntArrToComfy = async (blob: Blob | Uint8Array): Promise<ComfyUploadImageResult> => {
+    private uploadUIntArrToComfy = async (bytes: Uint8Array): Promise<ComfyUploadImageResult> => {
         const uploadURL = this.workspace.serverHostHTTP + '/upload/image'
         const form = new FormData()
-        form.append('image', blob, 'upload.png')
+        form.append('image', Buffer.from(bytes), { filename: 'upload.png' })
         const resp = await fetch(uploadURL, { method: 'POST', headers: form.getHeaders(), body: form })
         const result: ComfyUploadImageResult = (await resp.json()) as any
         console.log({ 'resp.data': result })


### PR DESCRIPTION
With a workflow like
```ts
... setup
const { images: [img] } = await flow.PROMPT()
await flow.uploadURL(img.comfyURL)
```
you would get a weird error saying `source.on` is not a function.
It seemed to be related to a bad usage of `FormData`
This PR attempts to fix that

Note that
```ts
… setup
graph.SaveImage({ filename_prefix: 'ComfyUI', images: vae })
const { images: [img] } = await flow.PROMPT()
await flow.uploadWorkspaceFile(img.localRelativeFilePath)
```
still currently errors because the image seems to be saved afterwards
![image](https://user-images.githubusercontent.com/2079561/232328698-a9a0428a-d551-41b2-9b53-680bb398db0b.png)

I'm not sure if that's normal ? and if so, how could we wait for images to be saved ?