### PR TITLE
Add InlineRun Widget

### DIFF
--- a/src/controls/FormBuilder.ts
+++ b/src/controls/FormBuilder.ts
@@ -28,6 +28,7 @@ export class FormBuilder {
     matrix = (opts: W.Widget_matrix_opts) => new W.Widget_matrix(this, this.schema, opts)
     boolean = (opts: W.Widget_bool_opts) => new W.Widget_bool(this, this.schema, opts)
     bool = (opts: W.Widget_bool_opts) => new W.Widget_bool(this, this.schema, opts)
+    inlineRun = (opts: W.Widget_inlineRun_opts) => new W.Widget_inlineRun(this, this.schema, opts)
     loras = (opts: W.Widget_loras_opts) => new W.Widget_loras(this, this.schema, opts)
     image = (opts: W.Widget_image_opts) => new W.Widget_image(this, this.schema, opts)
     markdown = (opts: W.Widget_markdown_opts) => new W.Widget_markdown(this, this.schema, opts)
@@ -65,6 +66,7 @@ export class FormBuilder {
     /** (@internal) advanced way to restore form state. used internally */
     _HYDRATE = (type: W.Widget['type'], input: any, serial?: any): any => {
         if (type === 'bool') return new W.Widget_bool(this, this.schema, input, serial)
+        if (type === 'inlineRun') return new W.Widget_inlineRun(this, this.schema, input, serial)
         if (type === 'str') return new W.Widget_str(this, this.schema, input, serial)
         if (type === 'strOpt') return new W.Widget_strOpt(this, this.schema, input, serial)
         if (type === 'int') return new W.Widget_int(this, this.schema, input, serial)

--- a/src/controls/Widget.ts
+++ b/src/controls/Widget.ts
@@ -29,6 +29,7 @@ export type Widget =
     | Widget_int
     | Widget_float
     | Widget_bool
+    | Widget_inlineRun
     | Widget_intOpt
     | Widget_floatOpt
     | Widget_markdown
@@ -357,6 +358,31 @@ export class Widget_bool implements IRequest<'bool', Widget_bool_opts, Widget_bo
     }
     get serial(): Widget_bool_serial { return this.state }
     get result(): Widget_bool_output { return this.state.active ? this.state.val : false}
+}
+
+// 🅿️ inlineRun ==============================================================================
+export type Widget_inlineRun_opts  = ReqInput<{}>
+export type Widget_inlineRun_serial = Widget_inlineRun_state
+export type Widget_inlineRun_state  = StateFields<{ type:'inlineRun', active: true; val: boolean }>
+export type Widget_inlineRun_output = boolean
+export interface Widget_inlineRun extends IWidget<'inlineRun', Widget_inlineRun_opts, Widget_inlineRun_serial, Widget_inlineRun_state, Widget_inlineRun_output> {}
+export class Widget_inlineRun implements IRequest<'inlineRun', Widget_inlineRun_opts, Widget_inlineRun_serial, Widget_inlineRun_state, Widget_inlineRun_output> {
+    isOptional = false
+    id: string
+    type: 'inlineRun' = 'inlineRun'
+    state: Widget_inlineRun_state
+    constructor(
+        public builder: FormBuilder,
+        public schema: SchemaL,
+        public input: Widget_inlineRun_opts,
+        serial?: Widget_inlineRun_serial,
+    ) {
+        this.id = serial?.id ?? nanoid()
+        this.state = serial ?? { type: 'inlineRun', id: this.id, active: true, val: false }
+        makeAutoObservable(this)
+    }
+    get serial(): Widget_inlineRun_serial { return this.state }
+    get result(): Widget_inlineRun_output { return this.state.active ? this.state.val : false}
 }
 
 // 🅿️ intOpt ==============================================================================
@@ -1368,6 +1394,7 @@ WidgetDI.Widget_seed=Widget_seed
 WidgetDI.Widget_int=Widget_int
 WidgetDI.Widget_float=Widget_float
 WidgetDI.Widget_bool=Widget_bool
+WidgetDI.Widget_inlineRun=Widget_inlineRun
 WidgetDI.Widget_intOpt=Widget_intOpt
 WidgetDI.Widget_floatOpt=Widget_floatOpt
 WidgetDI.Widget_markdown=Widget_markdown

--- a/src/controls/widgets/WidgetInlineRunUI.tsx
+++ b/src/controls/widgets/WidgetInlineRunUI.tsx
@@ -1,0 +1,34 @@
+import { observer } from 'mobx-react-lite'
+import { Widget_inlineRun } from 'src/controls/Widget'
+import { Button } from 'src/rsuite/shims'
+import { useDraft } from 'src/widgets/misc/useDraft'
+
+export const WidgetInlineRunUI = observer(function WidgetInlineRunUI_(p: { req: Widget_inlineRun }) {
+    const draft = useDraft()
+    return (
+        <Button
+            tw='btn-sm join-item btn-primary'
+            className='self-start'
+            icon={
+                draft.shouldAutoStart ? ( //
+                    <span className='material-symbols-outlined'>pause</span>
+                ) : (
+                    <span className='material-symbols-outlined'>play_arrow</span>
+                )
+            }
+            onClick={() => {
+                p.req.state.val = true
+                draft.setAutostart(false)
+                draft.start()
+
+                // Reset value back to false for future runs
+                setTimeout(() => {
+                    p.req.state.val = false
+                }, 100)
+            }}
+            // size={'sm'}
+        >
+            Run
+        </Button>
+    )
+})

--- a/src/controls/widgets/WidgetUI.DI.ts
+++ b/src/controls/widgets/WidgetUI.DI.ts
@@ -17,6 +17,7 @@ export let WidgetDI = {
     Widget_int: 0 as any as typeof R.Widget_int,
     Widget_float: 0 as any as typeof R.Widget_float,
     Widget_bool: 0 as any as typeof R.Widget_bool,
+    Widget_inlineRun: 0 as any as typeof R.Widget_inlineRun,
     Widget_intOpt: 0 as any as typeof R.Widget_intOpt,
     Widget_floatOpt: 0 as any as typeof R.Widget_floatOpt,
     Widget_markdown: 0 as any as typeof R.Widget_markdown,

--- a/src/controls/widgets/WidgetUI.tsx
+++ b/src/controls/widgets/WidgetUI.tsx
@@ -5,6 +5,7 @@ import { Message } from 'src/rsuite/shims'
 import { exhaust } from '../../utils/misc/ComfyUtils'
 import { WidgetPromptUI } from '../../widgets/prompter/WidgetPromptUI'
 import { WidgetBoolUI } from './WidgetBoolUI'
+import { WidgetInlineRunUI } from './WidgetInlineRunUI'
 import { WidgetChoiceUI } from './WidgetChoiceUI'
 import { WidgetChoicesUI } from './WidgetChoicesUI'
 import { WidgetColorUI } from './WidgetCololrUI'
@@ -50,6 +51,7 @@ export const WidgetUI = observer(function WidgetUI_(p: { req: R.Widget; focus?: 
     if (req instanceof R.Widget_enumOpt)            return <WidgetEnumUI        req={req} />
     if (req instanceof R.Widget_matrix)             return <WidgetMatrixUI      req={req} />
     if (req instanceof R.Widget_bool)               return <WidgetBoolUI        req={req} />
+    if (req instanceof R.Widget_inlineRun)          return <WidgetInlineRunUI   req={req} />
     if (req instanceof R.Widget_prompt)             return <WidgetPromptUI      req={req} />
     if (req instanceof R.Widget_promptOpt)          return <WidgetPromptUI      req={req} />
     if (req instanceof R.Widget_loras)              return <WidgetLorasUI       req={req} />

--- a/src/panels/Panel_Draft.tsx
+++ b/src/panels/Panel_Draft.tsx
@@ -141,7 +141,10 @@ export const RunOrAutorunUI = observer(function RunOrAutorunUI_(p: { className?:
                         <span className='material-symbols-outlined'>play_arrow</span>
                     )
                 }
-                onClick={() => draft.start()}
+                onClick={() => {
+                    draft.setAutostart(false)
+                    draft.start()
+                }}
                 // size={'sm'}
             >
                 Run


### PR DESCRIPTION
This has the same value as a form.bool({}), but it returns true only once when it is clicked. It is designed to be used in a `run` action to run specific parts of code:

Example:

```ts
 // ui
previewCrop: form.inlineRun({}),

// run
if (form.previewCrop) {
    graph.PreviewImage({ images: cropped_image })
    await flow.PROMPT()
    return
}
```

![image](https://github.com/rvion/CushyStudio/assets/703880/aecaf8ad-18c8-4511-b975-0f114a258a0d)


---

This also has a fix to the main button to disable the autorun if it is hit.
