### PR TITLE
quotes in dependency install paths

### DIFF
--- a/_windows_INSTALL.bat
+++ b/_windows_INSTALL.bat
@@ -34,13 +34,13 @@ IF NOT EXIST "%PNPM_BIN_PATH%" (
 
 :: Install dependencies using pnpm
 ECHO Installing dependencies...
-CALL %PNPM_BIN_PATH% install 
+CALL "%PNPM_BIN_PATH%" install 
 IF ERRORLEVEL 1 (
     ECHO Installing dependencies: node-gyp first...
-    CALL %PNPM_BIN_PATH% remove better-sqlite3
-    CALL %PNPM_BIN_PATH% install node-gyp
-    CALL %PNPM_BIN_PATH% install better-sqlite3
-    CALL %PNPM_BIN_PATH% install
+    CALL "%PNPM_BIN_PATH%" remove better-sqlite3
+    CALL "%PNPM_BIN_PATH%" install node-gyp
+    CALL "%PNPM_BIN_PATH%" install better-sqlite3
+    CALL "%PNPM_BIN_PATH%" install
 )
 
 :: ensuring binary dependencies are correctly linked across installed


### PR DESCRIPTION
Added quotes around the paths in the .bat file so paths with spaces don't fail