### PR TITLE
cnet interface cleanup

### DIFF
--- a/library/built-in/_prefabs/ControlNet/prefab_cnet_openPose.ts
+++ b/library/built-in/_prefabs/ControlNet/prefab_cnet_openPose.ts
@@ -1,6 +1,6 @@
 import { Cnet_args, cnet_preprocessor_ui_common, cnet_ui_common } from '../prefab_cnet'
 import { OutputFor } from '../_prefabs'
-import { getCurrentForm, getCurrentRun } from '../../../../src/models/_ctx2'
+import type { FormBuilder } from 'src/controls/FormBuilder'
 
 // 🅿️ OPEN POSE FORM ===================================================
 export const ui_subform_OpenPose = () => {
@@ -10,7 +10,7 @@ export const ui_subform_OpenPose = () => {
         customNodes: 'ComfyUI-Advanced-ControlNet',
         items: () => ({
             ...cnet_ui_common(form),
-            preprocessor: ui_subform_OpenPose_Preprocessor(),
+            preprocessor: ui_subform_OpenPose_Preprocessor(form),
             cnet_model_name: form.enum({
                 enumName: 'Enum_ControlNetLoader_control_net_name',
                 default: {
@@ -24,73 +24,77 @@ export const ui_subform_OpenPose = () => {
     })
 }
 
-export const ui_subform_OpenPose_Preprocessor = () => {
-    const form = getCurrentForm()
+export const ui_subform_OpenPose_Preprocessor = (form: FormBuilder) => {
     return form.groupOpt({
         label: 'Open Pose Preprocessor',
+        default: true,
         items: () => ({
-            ...cnet_preprocessor_ui_common(form),
-            detect_body: form.bool({ default: true }),
-            detect_face: form.bool({ default: true }),
-            detect_hand: form.bool({ default: true }),
-            useDWPose: form.bool({ default: true }),
-            bbox_detector: form.enum({
-                enumName: 'Enum_DWPreprocessor_bbox_detector',
-                default: 'yolox_l.onnx',
-                group: 'DW Pose',
-                label: 'Model',
+            advanced: form.groupOpt({
+                label: 'Advanced Preprocessor Settings',
+                items: () => ({
+                    ...cnet_preprocessor_ui_common(form),
+                    detect_body: form.bool({ default: true }),
+                    detect_face: form.bool({ default: true }),
+                    detect_hand: form.bool({ default: true }),
+                    useDWPose: form.bool({ default: true }),
+                    bbox_detector: form.enum({
+                        enumName: 'Enum_DWPreprocessor_bbox_detector',
+                        default: 'yolox_l.onnx',
+                        group: 'DW Pose',
+                        label: 'Model',
+                    }),
+                    pose_estimator: form.enum({
+                        enumName: 'Enum_DWPreprocessor_pose_estimator',
+                        default: 'dw-ll_ucoco_384.onnx',
+                        group: 'DW Pose',
+                        label: 'Model',
+                    }),
+                    // TODO: Add support for auto-modifying the resolution based on other form selections
+                    // TODO: Add support for auto-cropping
+                }),
             }),
-            pose_estimator: form.enum({
-                enumName: 'Enum_DWPreprocessor_pose_estimator',
-                default: 'dw-ll_ucoco_384.onnx',
-                group: 'DW Pose',
-                label: 'Model',
-            }),
-            // TODO: Add support for auto-modifying the resolution based on other form selections
-            // TODO: Add support for auto-cropping
         }),
     })
 }
 
 // 🅿️ OPEN POSE RUN ===================================================
-export const run_cnet_openPose = async (openPose: OutputFor<typeof ui_subform_OpenPose>, cnet_args: Cnet_args) => {
+export const run_cnet_openPose = async (openPose: OutputFor<typeof ui_subform_OpenPose>, cnet_args: Cnet_args, image: _IMAGE) => {
     const run = getCurrentRun()
     const graph = run.nodes
-    let image: IMAGE
     const cnet_name = openPose.cnet_model_name
 
     //crop the image to the right size
     //todo: make these editable
     image = graph.ImageScale({
-        image: (await run.loadImageAnswer(openPose.image))._IMAGE,
+        image,
         width: cnet_args.width ?? 512,
         height: cnet_args.height ?? 512,
-        upscale_method: openPose.upscale_method,
-        crop: openPose.crop,
+        upscale_method: openPose.advanced?.upscale_method ?? 'lanczos',
+        crop: openPose.advanced?.crop ?? 'center',
     })._IMAGE
 
     if (openPose.preprocessor) {
         var opPP = openPose.preprocessor
-        if (opPP.useDWPose) {
-            image = graph.DWPreprocessor({
-                image: image,
-                detect_body: opPP.detect_body ? 'enable' : 'disable',
-                detect_face: opPP.detect_face ? 'enable' : 'disable',
-                detect_hand: opPP.detect_hand ? 'enable' : 'disable',
-                resolution: opPP.resolution,
-                bbox_detector: opPP.bbox_detector,
-                pose_estimator: opPP.pose_estimator,
-            })._IMAGE
-        } else {
+        if (!opPP.advanced?.useDWPose) {
             image = graph.OpenposePreprocessor({
                 image: image,
-                detect_body: opPP.detect_body ? 'enable' : 'disable',
-                detect_face: opPP.detect_face ? 'enable' : 'disable',
-                detect_hand: opPP.detect_hand ? 'enable' : 'disable',
-                resolution: opPP.resolution,
+                detect_body: !opPP.advanced || opPP.advanced.detect_body ? 'enable' : 'disable',
+                detect_face: !opPP.advanced || opPP.advanced.detect_face ? 'enable' : 'disable',
+                detect_hand: !opPP.advanced || opPP.advanced.detect_hand ? 'enable' : 'disable',
+                resolution: opPP.advanced?.resolution ?? 512,
+            })._IMAGE
+        } else {
+            image = graph.DWPreprocessor({
+                image: image,
+                detect_body: !opPP.advanced || opPP.advanced.detect_body ? 'enable' : 'disable',
+                detect_face: !opPP.advanced || opPP.advanced.detect_face ? 'enable' : 'disable',
+                detect_hand: !opPP.advanced || opPP.advanced.detect_hand ? 'enable' : 'disable',
+                resolution: opPP.advanced.resolution,
+                bbox_detector: opPP.advanced.bbox_detector,
+                pose_estimator: opPP.advanced.pose_estimator,
             })._IMAGE
         }
-        if (opPP.saveProcessedImage) graph.SaveImage({ images: image, filename_prefix: 'cnet\\pose\\' })
+        if (opPP.advanced?.saveProcessedImage) graph.SaveImage({ images: image, filename_prefix: 'cnet\\pose\\' })
         else graph.PreviewImage({ images: image })
     }
 

--- a/library/built-in/_prefabs/ControlNet/prefab_cnet_softEdge.ts
+++ b/library/built-in/_prefabs/ControlNet/prefab_cnet_softEdge.ts
@@ -26,16 +26,22 @@ export const ui_subform_SoftEdge = () => {
 export const ui_subform_SoftEdge_Preprocessor = (form: FormBuilder) => {
     return form.groupOpt({
         label: 'SoftEdge Edge Preprocessor',
+        default: true,
         items: () => ({
-            type: form.choice({
-                label: 'Type',
+            advanced: form.groupOpt({
+                label: 'Advanced Preprocessor Settings',
                 items: () => ({
-                    HED: ui_subform_SoftEdge_Preprocessor_Options(form),
-                    PiDiNet: ui_subform_SoftEdge_Preprocessor_Options(form),
+                    type: form.choice({
+                        label: 'Type',
+                        items: () => ({
+                            HED: ui_subform_SoftEdge_Preprocessor_Options(form),
+                            PiDiNet: ui_subform_SoftEdge_Preprocessor_Options(form),
+                        }),
+                    }),
+                    // TODO: Add support for auto-modifying the resolution based on other form selections
+                    // TODO: Add support for auto-cropping
                 }),
             }),
-            // TODO: Add support for auto-modifying the resolution based on other form selections
-            // TODO: Add support for auto-cropping
         }),
     })
 }
@@ -51,33 +57,23 @@ export const ui_subform_SoftEdge_Preprocessor_Options = (form: FormBuilder) => {
 }
 
 // 🅿️ SoftEdge RUN ===================================================
-export const run_cnet_SoftEdge = async (SoftEdge: OutputFor<typeof ui_subform_SoftEdge>, cnet_args: Cnet_args) => {
+export const run_cnet_SoftEdge = async (SoftEdge: OutputFor<typeof ui_subform_SoftEdge>, cnet_args: Cnet_args, image: IMAGE) => {
     const run = getCurrentRun()
     const graph = run.nodes
-    let image: IMAGE
     const cnet_name = SoftEdge.cnet_model_name
     //crop the image to the right size
     //todo: make these editable
     image = graph.ImageScale({
-        image: (await run.loadImageAnswer(SoftEdge.image))._IMAGE,
+        image,
         width: cnet_args.width ?? 512,
         height: cnet_args.height ?? 512,
-        upscale_method: SoftEdge.upscale_method,
-        crop: SoftEdge.crop,
+        upscale_method: SoftEdge.advanced?.upscale_method ?? 'lanczos',
+        crop: SoftEdge.advanced?.crop ?? 'center',
     })._IMAGE
 
     // PREPROCESSOR - SoftEdge ===========================================================
-    if (SoftEdge.preprocessor?.type.HED) {
-        var hed = SoftEdge.preprocessor.type.HED
-        image = graph.HEDPreprocessor({
-            image: image,
-            resolution: hed.resolution,
-            safe: hed.safe ? 'enable' : 'disable',
-        })._IMAGE
-        if (hed.saveProcessedImage) graph.SaveImage({ images: image, filename_prefix: 'cnet\\SoftEdge\\hed' })
-        else graph.PreviewImage({ images: image })
-    } else if (SoftEdge.preprocessor?.type.PiDiNet) {
-        var pid = SoftEdge.preprocessor.type.PiDiNet
+    if (SoftEdge.preprocessor?.advanced?.type.PiDiNet) {
+        var pid = SoftEdge.preprocessor.advanced?.type.PiDiNet
         image = graph.PiDiNetPreprocessor({
             image: image,
             resolution: pid.resolution,
@@ -85,7 +81,15 @@ export const run_cnet_SoftEdge = async (SoftEdge: OutputFor<typeof ui_subform_So
         })._IMAGE
         if (pid.saveProcessedImage) graph.SaveImage({ images: image, filename_prefix: 'cnet\\SoftEdge\\pid' })
         else graph.PreviewImage({ images: image })
+    } else {
+        var hed = SoftEdge.preprocessor?.advanced?.type.HED
+        image = graph.HEDPreprocessor({
+            image: image,
+            resolution: hed?.resolution ?? 512,
+            safe: !hed || hed?.safe ? 'enable' : 'disable',
+        })._IMAGE
+        if (hed?.saveProcessedImage) graph.SaveImage({ images: image, filename_prefix: 'cnet\\SoftEdge\\hed' })
+        else graph.PreviewImage({ images: image })
     }
-
     return { cnet_name, image }
 }


### PR DESCRIPTION
Repackaged the cnet UI to allow multiple cnets on one image, and hid advanced settings so it is easier to manage

The second pass sampler change in SDUI is so that when a controlnet is used, the conditioning to the second pass is original (not cnet). Upscaled images look pretty weird when controlled.