### PR TITLE
UI: Set step size for SizeWidget to 32

### DIFF
--- a/src/controls/widgets/size/WidgetSizeUI.tsx
+++ b/src/controls/widgets/size/WidgetSizeUI.tsx
@@ -72,7 +72,7 @@ export const WigetSizeXUI = observer(function WigetSizeXUI_(p: {
                         //
                         min={p.bounds?.min ?? 128}
                         max={p.bounds?.max ?? 4096}
-                        step={p.bounds?.step ?? 256}
+                        step={p.bounds?.step ?? 32}
                         mode='int'
                         tw='join-item'
                         value={uist.width}
@@ -87,7 +87,7 @@ export const WigetSizeXUI = observer(function WigetSizeXUI_(p: {
                         tw='join-item'
                         min={p.bounds?.min ?? 128}
                         max={p.bounds?.max ?? 4096}
-                        step={p.bounds?.step ?? 256}
+                        step={p.bounds?.step ?? 32}
                         hideSlider
                         mode='int'
                         value={uist.height}


### PR DESCRIPTION
256 seems a bit high for image size
You can't use anything in between 512 and 768 easily, for example