### PR TITLE
Relative sliders part THREE!!!

### DIFF
--- a/src/controls/widgets/number/WidgetNumber.tsx
+++ b/src/controls/widgets/number/WidgetNumber.tsx
@@ -15,6 +15,7 @@ export type Widget_number_config = WidgetConfigFields<{
     softMin?: number
     softMax?: number
     step?: number
+    suffix?: string
     text?: string
     hideSlider?: boolean
     forceSnap?: boolean

--- a/src/controls/widgets/number/WidgetNumberUI.tsx
+++ b/src/controls/widgets/number/WidgetNumberUI.tsx
@@ -19,6 +19,7 @@ export const WidgetNumberUI = observer(function WidgetNumberUI_(p: { widget: Wid
             softMin={widget.config.softMin}
             softMax={widget.config.softMax}
             step={step}
+            suffix={widget.config.suffix}
             text={widget.config.text}
             onValueChange={(next) => (widget.serial.val = next)}
             forceSnap={widget.config.forceSnap}

--- a/src/controls/widgets/prompt/plugins/Plugin_AdjustWeights.tsx
+++ b/src/controls/widgets/prompt/plugins/Plugin_AdjustWeights.tsx
@@ -17,8 +17,8 @@ export const Plugin_AdjustWeightsUI = observer(function Plugin_AdjustWeightsUI_(
                         onValueChange={(v) => (weighted.weight = v)}
                         mode='float'
                         value={weighted.weight}
-                        min={0}
-                        max={2}
+                        softMin={0}
+                        softMax={2}
                     />
                     <div tw='line-clamp-1 whitespace-nowrap'>{weighted.contentText}</div>
                 </div>

--- a/src/controls/widgets/size/WidgetSizeUI.tsx
+++ b/src/controls/widgets/size/WidgetSizeUI.tsx
@@ -54,6 +54,7 @@ export const WidgetSizeX_LineUI = observer(function WidgetSize_LineUI_(p: {
                     onValueChange={(next) => uist.setWidth(next)}
                     forceSnap={true}
                     text='Width'
+                    suffix='px'
                 />
                 <div>x</div>
                 <InputNumberUI
@@ -68,6 +69,7 @@ export const WidgetSizeX_LineUI = observer(function WidgetSize_LineUI_(p: {
                     onValueChange={(next) => uist.setHeight(next)}
                     forceSnap={true}
                     text='Height'
+                    suffix='px'
                 />
             </div>
         </div>

--- a/src/rsuite/InputNumberUI.tsx
+++ b/src/rsuite/InputNumberUI.tsx
@@ -28,6 +28,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
     softMin?: number
     softMax?: number
     text?: string
+    suffix?: string
     hideSlider?: boolean
     style?: React.CSSProperties
     placeholder?: string
@@ -205,7 +206,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                         }}
                     >
                         <div className='text-container' tw='flex'>
-                            {p.text ? (
+                            {!isEditing && p.text ? (
                                 <div tw='primary-content outline-0 border-0 border-transparent z-10 w-full text-left'>
                                     {p.text}
                                 </div>
@@ -213,7 +214,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                             <input //
                                 type='text'
                                 tw={
-                                    p.text
+                                    !isEditing && p.text
                                         ? 'text-right cursor-not-allowed pointer-events-none'
                                         : 'text-center cursor-not-allowed pointer-events-none'
                                 }
@@ -261,6 +262,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                                     }
                                 }}
                             />
+                            {!isEditing && p.suffix ? <div style={{ zIndex: 2 }}>{p.suffix}</div> : <></>}
                         </div>
                         {/* <input //Setting the value to 0
                         type='range'

--- a/src/rsuite/InputNumberUI.tsx
+++ b/src/rsuite/InputNumberUI.tsx
@@ -6,11 +6,6 @@ import { parseFloatNoRoundingErr } from 'src/utils/misc/parseFloatNoRoundingErr'
 
 const clamp = (x: number, min: number, max: number) => Math.max(min, Math.min(max, x))
 
-/* TODO LIST:
- *   - Label
- *   - Suffix
- */
-
 /* NOTE(bird_d): Having these here should be fine since only one slider should be dragging/active at a time? */
 let startValue: number = 0
 let dragged: boolean = false
@@ -209,7 +204,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                                 console.log(
                                     '[InputNumberUI] Obtaining raw mouse input is not supported on this platform. Using processed mouse input, you may need to adjust the number input drag multiplier.',
                                 )
-                            activeSlider?.requestPointerLock()
+                                activeSlider?.requestPointerLock()
                             })
                         }}
                     >

--- a/src/rsuite/InputNumberUI.tsx
+++ b/src/rsuite/InputNumberUI.tsx
@@ -265,7 +265,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                                     }
                                 }}
                             />
-                            {!isEditing && p.suffix ? <div style={{ zIndex: 2 }}>{p.suffix}</div> : <></>}
+                            {!isEditing && p.suffix ? <div style={{ zIndex: 2, paddingLeft: 3 }}>{p.suffix}</div> : <></>}
                         </div>
                         {/* <input //Setting the value to 0
                         type='range'

--- a/src/rsuite/InputNumberUI.tsx
+++ b/src/rsuite/InputNumberUI.tsx
@@ -202,7 +202,15 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                             window.addEventListener('pointerlockchange', onPointerLockChange, true)
                             window.addEventListener('mousedown', cancelListener, true)
 
+                            /* Fix for low-sensitivity devices, it will get raw input from the mouse instead of the processed input.
+                             *  NOTE: This does not work on Linux right now, but when it does get added for Linux, this code should not need to be changed.
+                             */
+                            activeSlider?.requestPointerLock({ unadjustedMovement: true }).catch((error) => {
+                                console.log(
+                                    '[InputNumberUI] Obtaining raw mouse input is not supported on this platform. Using processed mouse input, you may need to adjust the number input drag multiplier.',
+                                )
                             activeSlider?.requestPointerLock()
+                            })
                         }}
                     >
                         <div className='text-container' tw='flex'>

--- a/src/rsuite/InputNumberUI.tsx
+++ b/src/rsuite/InputNumberUI.tsx
@@ -119,11 +119,11 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
 
     const onPointerUpListener = (e: MouseEvent) => {
         if (activeSlider && !dragged) {
-            let numberInput = activeSlider?.querySelector('input[type="number"') as HTMLInputElement
+            let textInput = activeSlider?.querySelector('input[type="text"') as HTMLInputElement
 
-            numberInput.setAttribute('cursor', 'not-allowed')
-            numberInput.setAttribute('cursor', 'none')
-            numberInput.focus()
+            textInput.setAttribute('cursor', 'not-allowed')
+            textInput.setAttribute('cursor', 'none')
+            textInput.focus()
         } else {
             activeSlider = null
         }
@@ -211,8 +211,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                                 </div>
                             ) : null}
                             <input //
-                                id='sliderNumberInput'
-                                type='number'
+                                type='text'
                                 tw={
                                     p.text
                                         ? 'text-right cursor-not-allowed pointer-events-none'
@@ -232,10 +231,10 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                                     setInputValue(ev?.target.value)
                                 }}
                                 onFocus={(ev) => {
-                                    let numberInput = ev.currentTarget
-                                    activeSlider = numberInput.parentElement as HTMLDivElement
+                                    let textInput = ev.currentTarget
+                                    activeSlider = textInput.parentElement as HTMLDivElement
 
-                                    numberInput.select()
+                                    textInput.select()
                                     startValue = val
                                     setInputValue(val.toString())
                                     setEditing(true)

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -261,6 +261,9 @@ input.input {
     border-width: 0px !important;
     padding-left: 5px;
     font-size: 15px;
+    
+    /* TODO(bird_d): This should be moved to be under all text, not just for number input. */
+    text-shadow: 0px 1px 1px var(--text-shadow-color), 1px 1px 1px var(--text-shadow-color), -1px 1px 1px var(--text-shadow-color);
 }
 
 /* /Slider */

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -132,6 +132,7 @@ body {
 /* Container holding buttons, range, and number input */
 .relative-slider {
     --input-number-ui-bg: oklch(var(--p)/.15);
+    --text-shadow-color: rgb(0, 0, 0, 0.2);
     border: 1px solid oklch(var(--pc)/.2);
     border-radius: 5px;
 }
@@ -201,23 +202,22 @@ input.input {
     background: oklch(var(--p)/.4);
 }
 
-.relative-slider input[type="number"] {
+.relative-slider input[type="text"] {
     appearance: textfield;
     -moz-appearance: textfield; /* Firefox */
     pointer-events: none;
     width: 100%;
-    --shadow-color: rgb(0, 0, 0, 0.2);
-    /* TODO(bird_d): This should be moved to be under all text, not just for sliders. */
-    text-shadow: 0px 1px 1px var(--shadow-color), 1px 1px 1px var(--shadow-color), -1px 1px 1px var(--shadow-color);
+    /* TODO(bird_d): This should be moved to be under all text, not just for number input. */
+    text-shadow: 0px 1px 1px var(--text-shadow-color), 1px 1px 1px var(--text-shadow-color), -1px 1px 1px var(--text-shadow-color);
     border-width: 0px;
 }
 
-.relative-slider input[type="number"]:focus {
+.relative-slider input[type="text"]:focus {
     outline: none;
     border-color: transparent;
 }
 
-.relative-slider input[type="number"]::selection {
+.relative-slider input[type="text"]::selection {
     background-color: oklch(var(--pc));
 }
 

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -131,6 +131,7 @@ body {
 
 /* Container holding buttons, range, and number input */
 .relative-slider {
+    --button-width: 16px;
     --input-number-ui-bg: oklch(var(--p)/.15);
     --text-shadow-color: rgb(0, 0, 0, 0.2);
     border: 1px solid oklch(var(--pc)/.2);
@@ -225,14 +226,16 @@ input.input {
     display: hidden;
     opacity: 0;
     border-width: 0px;
-    background-color: oklch(var(--input-number-ui-bg)*1.2);
-    outline-width: 0px;
+    background-color: oklch(var(--b2));
+    padding: 0px;
+    width: var(--button-width);
+    border-radius: 3px;
 }
 
 .relative-slider:hover button {
     display: unset;
     opacity: 100;
-    background-color: oklch(var(--pc)/0.5);
+    background-color: oklch(var(--b2));
 }
 
 .relative-slider button:hover {
@@ -259,7 +262,7 @@ input.input {
     align-content: end;
     background: transparent !important;
     border-width: 0px !important;
-    padding-left: 5px;
+    padding: 0px calc(var(--button-width) + 2px) 0px calc(var(--button-width) + 2px);
     font-size: 15px;
     
     /* TODO(bird_d): This should be moved to be under all text, not just for number input. */


### PR DESCRIPTION
We counted higher than Valve edition.

Changes to \<InputNumberUI/\>
- Add suffix option
- Set the input type to text, so the input will allow you to type whatever you want.
- Attempted fix for sliders being agonizing to drag for people with low sensitivity set for their mouse.
    It does this by attempting to pass {unadjustedMovement: true} to requestPointerLock(), which should get the raw mouse input instead of processed mouse input. This will not fix the issue for people on Linux as Chromium hasn't implemented the option to work there yet.