### PR TITLE
Change behaviour of 'Edit App Definition'

### DIFF
--- a/src/config/ConfigFile.ts
+++ b/src/config/ConfigFile.ts
@@ -20,8 +20,8 @@ export type ConfigFile = {
         }
     }
 
-    /** defaults to `code`, but a little bird once told me it could be `codium` */
-    vscodeBinaryName?: string
+    /** setting this option will make 'Edit App Definition' attempt to use this text editor first, then code/codium, then the system default text editor */
+    preferredTextEditor?: string
 
     /** prefer dense form */
     preferedFormLayout?: PreferedFormLayout

--- a/src/panels/Panel_Config.tsx
+++ b/src/panels/Panel_Config.tsx
@@ -32,13 +32,13 @@ export const Panel_Config = observer(function Panel_Config_() {
                         }}
                     />
                 </FieldUI>
-                <FieldUI label='Set vscode Binary Name (code, codium, ...)'>
+                <FieldUI label='Preferred Text Editor'>
                     <input
                         tw='input input-bordered input-sm w-full'
-                        name='vscodeBinaryName'
-                        value={config.get('vscodeBinaryName') ?? 'code'}
+                        name='preferredTextEditor'
+                        value={config.get('preferredTextEditor') ?? ''}
                         onChange={(ev) => {
-                            config.update({ vscodeBinaryName: ev.target.value })
+                            config.update({ preferredTextEditor: ev.target.value })
                             st.updateTsConfig()
                         }}
                     />

--- a/src/utils/electron/openInVsCode.ts
+++ b/src/utils/electron/openInVsCode.ts
@@ -67,7 +67,7 @@ export async function openInVSCode(st: STATE, filePathWithinWorkspace: string): 
 
                 /* Open with preferred editor, or default text editor */
                 try {
-                    let result = await tryEditor(editor, absoluteFilePath)
+                    let result = await tryEditor(command, absoluteFilePath)
                     usingVSCode = false
                     foundWorkingEditor = true
                     break

--- a/src/utils/electron/openInVsCode.ts
+++ b/src/utils/electron/openInVsCode.ts
@@ -1,15 +1,29 @@
 import type { STATE } from 'src/state/state'
-import { exec } from 'child_process'
+import { exec, execSync } from 'child_process'
 import { existsSync } from 'fs'
 import { resolve as pathResolve } from 'pathe'
 
 import { cwd } from 'process'
-import { toastError } from '../misc/toasts'
+import { toastError, toastInfo } from '../misc/toasts'
 
 const workspaceFolderPath = cwd()
 
-export async function openInVSCode(st: STATE, filePathWithinWorkspace: string): Promise<void> {
+/* Probably un-needed function, but this makes sure that we keep the UI non-blocking */
+async function tryEditor(editor: string, filePath: string): Promise<void> {
     return new Promise((resolvePromise, rejectPromise) => {
+        exec(`${editor} ${filePath}`, (error, stdout, stderr) => {
+            if (!error) {
+                resolvePromise()
+            } else {
+                let errMsg = new Error(`Could not open file with ${editor}: ${error.message}`)
+                rejectPromise(errMsg)
+            }
+        })
+    })
+}
+
+export async function openInVSCode(st: STATE, filePathWithinWorkspace: string): Promise<void> {
+    return new Promise(async (resolvePromise, rejectPromise) => {
         // Resolve and check the existence of the workspace and file paths
         const absoluteWorkspacePath = pathResolve(workspaceFolderPath)
         const absoluteFilePath = pathResolve(workspaceFolderPath, filePathWithinWorkspace)
@@ -30,27 +44,58 @@ export async function openInVSCode(st: STATE, filePathWithinWorkspace: string): 
             return
         }
 
-        const vscodeBinaryName = st.configFile.get('vscodeBinaryName') ?? 'code'
-        // First, open the folder in VSCode
-        exec(`${vscodeBinaryName} "${absoluteWorkspacePath}"`, (error) => {
-            if (error) {
-                const errMsg = `Error opening the workspace in VSCode: ${error.message}`
-                toastError(errMsg)
-                rejectPromise(new Error(errMsg))
-                return
-            }
+        const preferredEditor = st.configFile.get('preferredTextEditor')
 
-            // Then, focus on the specific file within the workspace
-            exec(`${vscodeBinaryName} -r "${absoluteFilePath}"`, (error) => {
-                if (error) {
-                    const errMsg = `Error opening the file in VSCode: ${error.message}`
-                    toastError(errMsg)
-                    rejectPromise(new Error(errMsg))
-                    return
+        /* Build list of editors by priority, inserting the user's preferred option to the front */
+        let textEditors = ['code', 'codium', 'default']
+        if (preferredEditor && textEditors.indexOf(preferredEditor) === -1) {
+            textEditors.unshift(preferredEditor)
+        }
+
+        let foundWorkingEditor = false
+        let usingVSCode = true
+        /* Attempt to open in user preferred text editor, then VSCode/Codium as we support that
+         *  editor the best, then use the system's default text editor. */
+        for (let editor of textEditors) {
+            if (['code', 'codium'].indexOf(editor) === -1) {
+                /* Open the file in the default text editor */
+                let command = editor
+
+                if (command == 'default') {
+                    command = process.platform === 'win32' ? 'start' : process.platform === 'darwin' ? 'open' : 'xdg-open'
                 }
 
-                resolvePromise()
-            })
-        })
+                /* Open with preferred editor, or default text editor */
+                try {
+                    let result = await tryEditor(editor, absoluteFilePath)
+                    usingVSCode = false
+                    foundWorkingEditor = true
+                    break
+                } catch (err) {
+                    console.log(`Could not open in ${editor}: ${err}`)
+                }
+            } else {
+                /* Open with VSCode/Codium */
+                try {
+                    await tryEditor(editor, absoluteWorkspacePath)
+                    await tryEditor(editor, absoluteFilePath)
+                    foundWorkingEditor = true
+                    break
+                } catch (err) {
+                    console.log(`Could not open in ${editor}: ${err}`)
+                }
+            }
+        }
+
+        if (foundWorkingEditor) {
+            if (!usingVSCode) {
+                toastInfo(
+                    'You are not using VSCode/Codium, these editors are recommended as they are supported to autocomplete various things.',
+                )
+            }
+            resolvePromise()
+        } else {
+            rejectPromise(new Error('Could not open file in any text editor.'))
+        }
     })
 }


### PR DESCRIPTION
Changes config 'VSCode binary' to 'Preferred Text Editor'
It will now attempt to open files in these editors, in this order:
- Preferred
- code
- codium
- System default

If it fails to run code/codium, but succeeds with a different editor, it will give a warning saying that you should use VSCode/Codium instead.
System default is untested on Windows/Mac, but I'm assuming it works.