### PR TITLE
Add support for custom ckpt config and CFG rescale

### DIFF
--- a/library/built-in/CushyDiffusion.ts
+++ b/library/built-in/CushyDiffusion.ts
@@ -97,6 +97,10 @@ app({
         // MODEL, clip skip, vae, etc. ---------------------------------------------------------------
         let { ckpt, vae, clip } = run_model(ui.model)
 
+        if (ui.model.extra.rescale_cfg) {
+            ckpt = graph.RescaleCFG({ model: ckpt, multiplier: ui.model.extra.rescale_cfg.multiplier })
+        }
+
         // RICH PROMPT ENGINE -------- ---------------------------------------------------------------
         const posPrompt = run_prompt({
             prompt: ui.positive,


### PR DESCRIPTION
Models I use often have an override config. ComfyUI's function to 'guess config' does not work like Automatic's, which loads a config yaml by the checkpoint name.

In Comfy, the SimpleCheckpointLoader does not do this, it instead scans the unet_config in the checkpoint itself and then compares it to a list of known architectures before picking one.

If you want to use a model which comes with a separate config, as many experimental V-Prediction models do, you have to use the frighteningly named (deprecated) CheckpointLoader. 

In this PR I add to the built in Cushy Diffusion an extra button to indicate a config, which then triggers the other loader in the run step.

Coincidentally such models also tend to need CFGRescale, so I added another extra config to enable that node in the graph as well.