### PR TITLE
Quick Tweaks

### DIFF
--- a/library/built-in/_prefabs/prefab_latent_v3.ts
+++ b/library/built-in/_prefabs/prefab_latent_v3.ts
@@ -14,7 +14,7 @@ export const ui_latent_v3 = () => {
                 form.group({
                     collapsible: false,
                     label: false,
-                    items: { batchSize, size: form.size({ label: false }) },
+                    items: { batchSize, size: form.size({ label: false, default: { modelType: 'SDXL 1024' } }) },
                 }),
             image: () =>
                 form.group({

--- a/src/controls/widgets/choices/WidgetChoicesUI.tsx
+++ b/src/controls/widgets/choices/WidgetChoicesUI.tsx
@@ -74,11 +74,11 @@ const WidgetChoices_TabLineUI = observer(function WidgetChoicesTab_LineUI_(p: {
                         tw={[
                             //
                             'cursor-pointer',
-                            'rounded text-shadow',
+                            'rounded',
                             'border px-2 flex flex-nowrap gap-0.5 whitespace-nowrap items-center bg-base-100',
                             isSelected
-                                ? 'bg-primary text-base-300 border-base-200'
-                                : 'bg-base-200 hover:filter hover:brightness-110 border-base-100',
+                                ? 'bg-primary text-base-300 border-base-200 text-shadow-inv'
+                                : 'bg-base-200 hover:filter hover:brightness-110 border-base-100 text-shadow',
                             'border-b-2 border-b-base-300',
                         ]}
                     >

--- a/src/controls/widgets/size/WidgetSize.ts
+++ b/src/controls/widgets/size/WidgetSize.ts
@@ -42,8 +42,8 @@ export class Widget_size
         } else {
             const aspectRatio: AspectRatio = config.default?.aspectRatio ?? '1:1'
             const modelType: SDModelType = config.default?.modelType ?? 'SD1.5 512'
-            const width = 512 // 🔴
-            const height = 512 // 🔴
+            const width = config.default?.width ?? parseInt(modelType.split(' ')[1])
+            const height = config.default?.height ?? parseInt(modelType.split(' ')[1])
             this.serial = {
                 type: 'size',
                 id: this.id,

--- a/src/controls/widgets/size/WidgetSizeTypes.ts
+++ b/src/controls/widgets/size/WidgetSizeTypes.ts
@@ -3,7 +3,6 @@ export type SDModelType =
     | 'SD1.5 512'
     | 'SD2.1 768'
     | 'SDXL 1024'
-    | 'custom 512'
 
 export type CushySizeByRatio = {
     modelType?: SDModelType

--- a/src/controls/widgets/size/WidgetSizeTypes.ts
+++ b/src/controls/widgets/size/WidgetSizeTypes.ts
@@ -3,11 +3,13 @@ export type SDModelType =
     | 'SD1.5 512'
     | 'SD2.1 768'
     | 'SDXL 1024'
-    | 'custom'
+    | 'custom 512'
 
 export type CushySizeByRatio = {
-    modelType: SDModelType
-    aspectRatio: AspectRatio
+    modelType?: SDModelType
+    aspectRatio?: AspectRatio
+    width?: number
+    height?: number
 }
 
 export type CushySize = {

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -160,7 +160,7 @@ body {
 .relative-slider {
     --button-width: 16px;
     --input-number-ui-bg: oklch(var(--p)/.15);
-    --text-shadow-color: rgb(0, 0, 0, 0.2);
+    
     border: 1px solid oklch(var(--pc)/.2);
     border-radius: 5px;
 }
@@ -292,17 +292,17 @@ input.input {
     padding: 0px calc(var(--button-width) + 2px) 0px calc(var(--button-width) + 2px);
     font-size: 15px;
 
-    /* TODO(bird_d): This should be moved to be under all text, not just for number input. */
+}
+
+/* //Slider */
+
+/* Text Shading - These are defined in theme.css*/
+.text-shadow {
     text-shadow: 0px 1px 1px var(--text-shadow-color), 1px 1px 1px var(--text-shadow-color), -1px 1px 1px var(--text-shadow-color);
 }
 
-/* /Slider */
-
-/* Text Shading */
-/* TODO(bird_d): This should be moved to be under all text, not just for number input. */
-.text-shadow {
-    --text-shadow-color: rgb(0, 0, 0, 0.2);
-    text-shadow: 0px 1px 1px var(--text-shadow-color), 1px 1px 1px var(--text-shadow-color), -1px 1px 1px var(--text-shadow-color);
+.text-shadow-inv {
+    text-shadow: 0px 1px 1px var(--text-shadow-color-inv), 1px 1px 1px var(--text-shadow-color-inv), -1px 1px 1px var(--text-shadow-color-inv);
 }
 
 .bg-primary-1 { background-color: oklch(var(--p)/.1); }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,16 @@ const notReallyRound = {
     '--btn-focus-scale': '1',
 }
 
+const lightGlobals = {
+    '--text-shadow-color': 'rgb(255, 255, 255, 0.1)',
+    '--text-shadow-color-inv' : 'rgb(0, 0, 0, 0.2)'
+}
+
+const darkGlobals = {
+    '--text-shadow-color': 'rgb(0, 0, 0, 0.2)',
+    '--text-shadow-color-inv' : 'rgb(255, 255, 255, 0.1)'
+}
+
 module.exports = {
     content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}', './library/**/*.{ts,js}'],
     theme: {
@@ -29,6 +39,7 @@ module.exports = {
                     ...require('daisyui/src/theming/themes')['corporate'],
                     'primary-content': 'white',
                     ...notReallyRound,
+                    ...lightGlobals,
                 },
             },
             {
@@ -37,6 +48,7 @@ module.exports = {
                     primary: '#5aa474',
                     'primary-content': 'white',
                     ...notReallyRound,
+                    ...lightGlobals,
                 },
             },
             // 'dark',
@@ -61,12 +73,14 @@ module.exports = {
                     'base-300': '#191c23',
                     'base-content': '#B2CCD6',
                     ...notReallyRound,
+                    ...darkGlobals,
                 },
             },
             {
                 dark2: {
                     ...require('daisyui/src/theming/themes')['dim'],
                     ...notReallyRound,
+                    ...darkGlobals,
                 },
             },
             {
@@ -74,6 +88,7 @@ module.exports = {
                     ...require('daisyui/src/theming/themes')['dark'],
                     primary: '#9FA8DA',
                     ...notReallyRound,
+                    ...darkGlobals,
                 },
             },
             // 'wireframe',
@@ -81,12 +96,14 @@ module.exports = {
                 wireframe: {
                     ...require('daisyui/src/theming/themes')['wireframe'],
                     ...notReallyRound,
+                    ...lightGlobals,
                 },
             },
             {
                 cupcake: {
                     ...require('daisyui/src/theming/themes')['cupcake'],
                     ...notReallyRound,
+                    ...lightGlobals,
                 },
             },
             'aqua',
@@ -94,6 +111,7 @@ module.exports = {
                 valentine: {
                     ...require('daisyui/src/theming/themes')['valentine'],
                     ...notReallyRound,
+                    ...lightGlobals,
                 },
             },
             'sunset',


### PR DESCRIPTION
- text-shadow and text-shadow-inv option for tailwind/className.
- use this to have the UI not look as bad when dark on light text.
- Add default options for dimensions of size widget, also makes it so just setting the modelType will use the model's size