### PR TITLE
UI: Overhaul InputNumberUI (again), improve Search enum widget, and minor changes

### DIFF
--- a/library/built-in/_prefabs/prefab_latent_v3.ts
+++ b/library/built-in/_prefabs/prefab_latent_v3.ts
@@ -14,7 +14,7 @@ export const ui_latent_v3 = () => {
                 form.group({
                     collapsible: false,
                     label: false,
-                    items: { batchSize, size: form.size({ label: false, default: { modelType: 'SDXL 1024' } }) },
+                    items: { batchSize, size: form.size({ label: false }) },
                 }),
             image: () =>
                 form.group({

--- a/src/controls/widgets/WidgetSelectOneUI.tsx
+++ b/src/controls/widgets/WidgetSelectOneUI.tsx
@@ -11,7 +11,7 @@ export const WidgetSelectOneUI = observer(function WidgetSelectOneUI_<T extends 
         const selected = widget.serial.val
         return (
             <div>
-                <div role='tablist' tw='tabs tabs-boxed tabs-sm flex-wrap text-shadow'>
+                <div role='tablist' tw='tabs tabs-boxed tabs-sm flex-wrap'>
                     {widget.choices.map((c) => {
                         const isSelected = selected?.id === c.id
                         return (
@@ -19,7 +19,7 @@ export const WidgetSelectOneUI = observer(function WidgetSelectOneUI_<T extends 
                                 onClick={() => (widget.serial.val = c)}
                                 key={c.id}
                                 role='tab'
-                                tw={['tab', isSelected && 'tab-active']}
+                                tw={['tab', isSelected ? 'tab-active text-shadow-inv' : 'text-shadow']}
                             >
                                 {c.label ?? makeLabelFromFieldName(c.id)}
                             </a>

--- a/src/rsuite/InputNumberUI.tsx
+++ b/src/rsuite/InputNumberUI.tsx
@@ -151,7 +151,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                 'input-number-ui custom-roundness',
                 'h-7 flex-1 select-none min-w-16 cursor-ew-resize overflow-clip',
                 'bg-primary/30 border border-base-100 border-b-2 border-b-base-200',
-                !isEditing && 'hover:border-base-200 hover:border-b-base-300',
+                !isEditing && 'hover:border-base-200 hover:border-b-base-300 hover:bg-primary/40',
             ]}
         >
             <div /* Container */ tw={['h-full relative w-full flex', 'border-0']}>
@@ -170,6 +170,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                     ◂
                 </button>
                 <div /* Slider display */
+                    className='inui-foreground'
                     tw={[!p.hideSlider && !isEditing && 'bg-primary/40']}
                     style={{ width: `${((val - rangeMin) / (rangeMax - rangeMin)) * 100}%` }}
                 />

--- a/src/rsuite/InputNumberUI.tsx
+++ b/src/rsuite/InputNumberUI.tsx
@@ -142,34 +142,40 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
         }
     }
 
-    return (
-        <div
-            //
-            className={p.className}
-            tw='relative-slider flex-1 select-none min-w-16'
-        >
-            <div tw='relative w-full flex'>
-                <progress
-                    style={{ zIndex: 1 }}
-                    tw='range range-primary cursor-not-allowed pointer-events-none'
-                    value={p.hideSlider ? 0 : val - rangeMin}
-                    max={rangeMax - rangeMin}
-                ></progress>
+    const buttonSize = 4
 
-                <div tw='absolute w-full rounded-sm flex'>
-                    <button
-                        tw='btn btn-xs absolute left-0'
-                        style={{ zIndex: 2 }}
-                        onClick={(_) => {
-                            startValue = val
-                            let num = val - (mode === 'int' ? step : step * 0.1)
-                            syncValues(num, true)
-                        }}
-                    >
-                        ◂
-                    </button>
+    return (
+        <div /* Root */
+            className={p.className}
+            tw={[
+                'input-number-ui custom-roundness',
+                'h-7 flex-1 select-none min-w-16 cursor-ew-resize overflow-clip',
+                'bg-primary/30 border border-base-100 border-b-2 border-b-base-200',
+                !isEditing && 'hover:border-base-200 hover:border-b-base-300',
+            ]}
+        >
+            <div /* Container */ tw={['h-full relative w-full flex', 'border-0']}>
+                <button /* Left Button */
+                    tw={[
+                        'h-full absolute left-0 rounded-none pr-0.5',
+                        `!w-${buttonSize} pb-1 leading-none border border-base-200 opacity-0 bg-base-200 hover:brightness-125`,
+                    ]}
+                    style={{ zIndex: 2 }}
+                    onClick={(_) => {
+                        startValue = val
+                        let num = val - (mode === 'int' ? step : step * 0.1)
+                        syncValues(num, true)
+                    }}
+                >
+                    ◂
+                </button>
+                <div /* Slider display */
+                    tw={[!p.hideSlider && !isEditing && 'bg-primary/40']}
+                    style={{ width: `${((val - rangeMin) / (rangeMax - rangeMin)) * 100}%` }}
+                />
+                <div tw='absolute flex w-full h-full px-1'>
                     <div
-                        tw='relative flex flex-1 select-none'
+                        tw={['relative flex flex-1 select-none']}
                         onWheel={(ev) => {
                             /* NOTE: This could probably divide by the length? But I'm not sure how to get the distance of 1 scroll tick.
                              * Increment/Decrement using scroll direction. */
@@ -182,7 +188,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                             }
                         }}
                         onMouseDown={(ev) => {
-                            if (ev.button != 0) {
+                            if (isEditing || ev.button != 0) {
                                 return
                             }
 
@@ -209,25 +215,35 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                             })
                         }}
                     >
-                        <div className='text-container' tw='flex'>
+                        <div /* Text Container */
+                            tw={[`custom-roundness flex-auto flex items-center !px-${buttonSize} text-sm text-shadow`]}
+                        >
                             {!isEditing && p.text ? (
-                                <div tw='primary-content outline-0 border-0 border-transparent z-10 w-full text-left'>
+                                <div /* Inner Label Text - Not shown while editing */
+                                    tw={['outline-0 border-0 border-transparent z-10 w-full text-left']}
+                                >
                                     {p.text}
                                 </div>
                             ) : null}
                             <input //
                                 type='text'
-                                tw={
-                                    !isEditing && p.text
-                                        ? 'text-right cursor-not-allowed pointer-events-none'
-                                        : 'text-center cursor-not-allowed pointer-events-none'
-                                }
+                                draggable='false'
+                                onDragStart={(ev) => {
+                                    /* Prevents drag n drop of selected text, so selecting is easier. */
+                                    ev.preventDefault()
+                                }}
+                                tw={[
+                                    'w-full text-shadow outline-0',
+                                    !isEditing && 'cursor-not-allowed pointer-events-none',
+                                    !isEditing && p.text ? 'text-right' : 'text-center',
+                                ]}
                                 value={isEditing ? inputValue : val}
                                 placeholder={p.placeholder}
                                 style={{
                                     fontFamily: 'monospace',
                                     zIndex: 2,
                                     background: 'transparent',
+                                    MozWindowDragging: 'no-drag',
                                 }}
                                 min={p.min}
                                 max={p.max}
@@ -279,19 +295,21 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                         readOnly
                     /> */}
                     </div>
-                    <button
-                        className='btn btn-xs'
-                        tw='btn btn-small absolute right-0'
-                        style={{ zIndex: 2 }}
-                        onClick={(_) => {
-                            startValue = val
-                            let num = val + (mode === 'int' ? step : step * 0.1)
-                            syncValues(num, true)
-                        }}
-                    >
-                        ▸
-                    </button>
                 </div>
+                <button /* Right Button */
+                    tw={[
+                        'h-full absolute right-0 pl-0.5',
+                        `!w-${buttonSize} pb-1 leading-none border border-base-200 opacity-0 bg-base-200 hover:brightness-125`,
+                    ]}
+                    style={{ zIndex: 2 }}
+                    onClick={(_) => {
+                        startValue = val
+                        let num = val + (mode === 'int' ? step : step * 0.1)
+                        syncValues(num, true)
+                    }}
+                >
+                    ▸
+                </button>
             </div>
         </div>
     )

--- a/src/rsuite/SelectUI.tsx
+++ b/src/rsuite/SelectUI.tsx
@@ -260,10 +260,8 @@ export const SelectUI = observer(function SelectUI_<T>(p: SelectProps<T>) {
 export const SelectPopupUI = observer(function SelectPopupUI_<T>(p: { s: AutoCompleteSelectState<T> }) {
     const s = p.s
     return createPortal(
-        <ul
-            onMouseLeave={s.onTooltipMouseOut}
-            className='_SelectPopupUI p-0.5 bg-base-100 max-h-96 overflow-auto'
-            tw='flex flex-col gap-0.5 p-1 rounded-b border-b border-l border-r border-base-300'
+        <div
+            tw={['MENU-ROOT _SelectPopupUI bg-base-100 flex', 'rounded-b border-b border-l border-r border-base-300']}
             style={{
                 minWidth: s.anchorRef.current?.clientWidth ?? '100%',
                 pointerEvents: 'initial',
@@ -275,49 +273,55 @@ export const SelectPopupUI = observer(function SelectPopupUI_<T>(p: { s: AutoCom
                 // Adjust positioning as needed
             }}
         >
-            {s.filteredOptions.length === 0 ? <li className='p-1 text-base'>No results</li> : null}
-            {s.filteredOptions.map((option, index) => {
-                const isSelected =
-                    s.values.find((v) => {
-                        if (s.p.equalityCheck != null) return s.p.equalityCheck(v, option)
-                        return v === option
-                    }) != null
-                return (
-                    <li
-                        key={index}
-                        style={{ minWidth: '10rem' }}
-                        className={`active:bg-base-300 cursor-pointer text-shadow ${
-                            index === s.selectedIndex && (isSelected ? '!text-primary-content text-shadow' : 'bg-base-300')
-                        }`}
-                        tw={[
-                            'flex items-center gap-1 rounded',
-                            isSelected && 'bg-primary text-primary-content hover:text-neutral-content text-shadow-inv',
-                        ]}
-                        onMouseEnter={(ev) => {
-                            s.setNavigationIndex(index)
-                        }}
-                        onMouseDown={(ev) => s.onMenuEntryClick(ev, index)}
-                    >
-                        <div tw={'rounded py-3 h-6'}>
-                            {s.isMultiSelect ? (
-                                <input
-                                    onChange={() => {}}
-                                    checked={isSelected}
-                                    type='checkbox'
-                                    tw='checkbox checkbox-primary checkbox-sm input-xs bg-none'
-                                />
-                            ) : (
-                                <></>
-                            )}
-                        </div>
-                        {/* {isSelected ? '🟢' : null} */}
-                        {s.p.getLabelUI //
-                            ? s.p.getLabelUI(option)
-                            : s.p.getLabelText(option)}
-                    </li>
-                )
-            })}
-        </ul>,
+            <ul
+                onMouseLeave={s.onTooltipMouseOut}
+                className='p-0.5 bg-base-100 max-h-96 overflow-auto'
+                tw='flex flex-col gap-0.5 p-1 w-full'
+            >
+                {s.filteredOptions.length === 0 ? <li className='p-1 text-base'>No results</li> : null}
+                {s.filteredOptions.map((option, index) => {
+                    const isSelected =
+                        s.values.find((v) => {
+                            if (s.p.equalityCheck != null) return s.p.equalityCheck(v, option)
+                            return v === option
+                        }) != null
+                    return (
+                        <li
+                            key={index}
+                            style={{ minWidth: '10rem' }}
+                            className={`active:bg-base-300 cursor-pointer text-shadow ${
+                                index === s.selectedIndex && (isSelected ? '!text-primary-content text-shadow' : 'bg-base-300')
+                            }`}
+                            tw={[
+                                'flex items-center gap-1 rounded',
+                                isSelected && 'bg-primary text-primary-content hover:text-neutral-content text-shadow-inv',
+                            ]}
+                            onMouseEnter={(ev) => {
+                                s.setNavigationIndex(index)
+                            }}
+                            onMouseDown={(ev) => s.onMenuEntryClick(ev, index)}
+                        >
+                            <div tw={'rounded py-3 h-6'}>
+                                {s.isMultiSelect ? (
+                                    <input
+                                        onChange={() => {}}
+                                        checked={isSelected}
+                                        type='checkbox'
+                                        tw='checkbox checkbox-primary checkbox-sm input-xs bg-none'
+                                    />
+                                ) : (
+                                    <></>
+                                )}
+                            </div>
+                            {/* {isSelected ? '🟢' : null} */}
+                            {s.p.getLabelUI //
+                                ? s.p.getLabelUI(option)
+                                : s.p.getLabelText(option)}
+                        </li>
+                    )
+                })}
+            </ul>
+        </div>,
         document.getElementById('tooltip-root')!,
     )
 })

--- a/src/rsuite/SelectUI.tsx
+++ b/src/rsuite/SelectUI.tsx
@@ -106,6 +106,7 @@ class AutoCompleteSelectState<T> {
     isOpen = false
 
     tooltipPosition = { top: 0, left: 0 }
+    tooltipMaxHeight = 100
     updatePosition = () => {
         const rect = this.anchorRef.current?.getBoundingClientRect()
         if (rect == null) return
@@ -113,6 +114,9 @@ class AutoCompleteSelectState<T> {
             top: rect.bottom + window.scrollY,
             left: rect.left + window.scrollX,
         }
+
+        /* Make sure to not go off-screen */
+        this.tooltipMaxHeight = window.innerHeight - rect.bottom - 8
     }
 
     onTooltipMouseOut = (ev: React.MouseEvent<HTMLUListElement, MouseEvent>) => {
@@ -258,8 +262,8 @@ export const SelectPopupUI = observer(function SelectPopupUI_<T>(p: { s: AutoCom
     return createPortal(
         <ul
             onMouseLeave={s.onTooltipMouseOut}
-            className='_SelectPopupUI p-0.5 bg-base-100 shadow-2xl max-h-96 overflow-auto'
-            tw='rounded-b border-b border-l border-r border-base-300 text-shadow'
+            className='_SelectPopupUI p-0.5 bg-base-100 max-h-96 overflow-auto'
+            tw='flex flex-col gap-0.5 p-1 rounded-b border-b border-l border-r border-base-300'
             style={{
                 minWidth: s.anchorRef.current?.clientWidth ?? '100%',
                 pointerEvents: 'initial',
@@ -267,6 +271,7 @@ export const SelectPopupUI = observer(function SelectPopupUI_<T>(p: { s: AutoCom
                 zIndex: 99999999,
                 top: `${s.tooltipPosition.top}px`,
                 left: `${s.tooltipPosition.left}px`,
+                maxHeight: `${s.tooltipMaxHeight}px`,
                 // Adjust positioning as needed
             }}
         >
@@ -281,17 +286,19 @@ export const SelectPopupUI = observer(function SelectPopupUI_<T>(p: { s: AutoCom
                     <li
                         key={index}
                         style={{ minWidth: '10rem' }}
-                        className={`active:bg-base-300 cursor-pointer ${index === s.selectedIndex ? 'bg-base-300' : ''}`}
+                        className={`active:bg-base-300 cursor-pointer text-shadow ${
+                            index === s.selectedIndex && (isSelected ? '!text-primary-content text-shadow' : 'bg-base-300')
+                        }`}
                         tw={[
                             'flex items-center gap-1 rounded',
-                            isSelected && 'bg-primary text-primary-content hover:text-neutral-content',
+                            isSelected && 'bg-primary text-primary-content hover:text-neutral-content text-shadow-inv',
                         ]}
                         onMouseEnter={(ev) => {
                             s.setNavigationIndex(index)
                         }}
                         onMouseDown={(ev) => s.onMenuEntryClick(ev, index)}
                     >
-                        <div tw={'rounded p-1 h-6'}>
+                        <div tw={'rounded py-3 h-6'}>
                             {s.isMultiSelect ? (
                                 <input
                                     onChange={() => {}}

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -181,6 +181,10 @@ input::-webkit-inner-spin-button {
     opacity: 100;
 }
 
+.input-number-ui:hover .inui-foreground {
+    filter: brightness(1.20)
+}
+
 /* //InputNumberUI */
 
 /* Text Shading - These are defined in theme.css*/

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -214,7 +214,7 @@ input::-webkit-inner-spin-button {
 ._SelectPopupUI,
 ._RevealUI {
     box-shadow:
-        0 5px 15px -5px oklch(var(--p));
+        0 2px 5px -2px oklch(var(--pc));
         /* 0 0 10px 1px oklch(var(--b3)); */
 }
 ._MenuItem > div  {

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -1,3 +1,11 @@
+#root {
+    --roundness: 5px;
+}
+
+.custom-roundness {
+    border-radius: var(--roundness);
+}
+
 #CushyStudio:focus {
     outline: none;
 }
@@ -153,148 +161,27 @@ body {
     background-image: none;
 }
 
-/* Slider   --------------------- */
-/* input[type='range']::-webkit-slider-runnable-track { height: 2rem; } */
-
-/* Container holding buttons, range, and number input */
-.relative-slider {
-    --button-width: 16px;
-    --input-number-ui-bg: oklch(var(--p)/.15);
-    
-    border: 1px solid oklch(var(--pc)/.2);
-    border-radius: 5px;
+input.input {
+    background-color: oklch(var( --p)/.15) !important;
 }
 
-.relative-slider div:first {
-    align-items: center;
-    /* border-radius: 5px !important; */
-    overflow: hidden;
-}
-
-.relative-slider:hover {
-    cursor: ew-resize;
-}
-
-.relative-slider div div:hover progress {
-    filter: brightness(1.2);
-}
-
-.relative-slider input::-webkit-outer-spin-button,
+/* InputNumberUI   --------------------- */
+.input-number-ui input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
     width: 0;
     height: 0;
     margin: 0;
 }
 
-/* .relative-slider input[type=range] {
-    position: absolute;
-    border-radius: 0px;
-}
-
-
-.relative-slider input[type=range]::-webkit-slider-runnable-track {
-    color: black;
-}
-
-.relative-slider input[type=range]::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    border: none;
-    height: 0px;
-    width: 0px;
-}
-
-.relative-slider input[type="range"]::-moz-range-thumb {
-    display: none;
-}
-
-.relative-slider input[type="range"]::-ms-thumb {
-    display: none;
-} */
-
-input.input {
-    background-color: oklch(var( --p)/.15) !important;
-}
-.relative-slider progress[value]::-webkit-progress-bar {
-    background-color: var(--input-number-ui-bg);
-    appearance: none;
-}
-
-.relative-slider:active progress[value]::-webkit-progress-bar {
-    background-color: oklch(var(--b3));
-    appearance: none;
-}
-
-.relative-slider progress[value]::-webkit-progress-value {
-    appearance: none;
-    opacity: 100;
-    background: oklch(var(--p)/.4);
-}
-
-.relative-slider input[type="text"] {
-    appearance: textfield;
-    -moz-appearance: textfield; /* Firefox */
-    pointer-events: none;
-    width: 100%;
-    /* TODO(bird_d): This should be moved to be under all text, not just for number input. */
-    text-shadow: 0px 1px 1px var(--text-shadow-color), 1px 1px 1px var(--text-shadow-color), -1px 1px 1px var(--text-shadow-color);
-    border-width: 0px;
-}
-
-.relative-slider input[type="text"]:focus {
-    outline: none;
-    border-color: transparent;
-}
-
-.relative-slider input[type="text"]::selection {
+.input-number-ui input[type="text"]::selection {
     background-color: oklch(var(--pc));
 }
 
-.relative-slider button, .relative-slider:active button {
-    display: hidden;
-    opacity: 0;
-    border-width: 0px;
-    background-color: oklch(var(--b2));
-    padding: 0px;
-    width: var(--button-width);
-    border-radius: 3px;
-}
-
-.relative-slider:hover button {
-    display: unset;
+.input-number-ui:hover button {
     opacity: 100;
-    background-color: oklch(var(--b2));
 }
 
-.relative-slider button:hover {
-    filter: brightness(1.2)
-}
-
-/* Left decrement button */
-.relative-slider button:nth-child(1) {
-    border-top-right-radius: 0px !important;
-    border-bottom-right-radius: 0px !important;
-    border-right: 1px solid oklch(var(--pc)/.2);
-}
-
-/* Right decrement button */
-.relative-slider button:nth-child(3) {
-    border-top-left-radius: 0px !important;
-    border-bottom-left-radius: 0px !important;
-    border-left: 1px solid oklch(var(--pc)/.2);
-}
-
-.relative-slider .text-container {
-    flex: auto;
-    text-align: right;
-    align-content: end;
-    background: transparent !important;
-    border-width: 0px !important;
-    padding: 0px calc(var(--button-width) + 2px) 0px calc(var(--button-width) + 2px);
-    font-size: 15px;
-
-}
-
-/* //Slider */
+/* //InputNumberUI */
 
 /* Text Shading - These are defined in theme.css*/
 .text-shadow {


### PR DESCRIPTION
InputNumberUI
- Move as much as possible from raw CSS to Tailwind
- Can now use mouse to select text, also trying to select selected text will not start a drag and drop.
- Moved things around a bit, could still probably be cleaned up a bit more

SelectUI
- No longer can be too large and go off-screen
- CSS adjustments
Note: Need to work out how to make it not close on click, so people can use the mouse to drag the scrollbar. Not a big deal as I don't *think* there's a menu that will have that many options though, or someone without a scroll-wheel in 2024.

SelectOneUI
- Add the new text-shadow/inv

Get rid of the mistakenly set modelType default for the latent_v3 prefab