### PR TITLE
MediaImage: Add copyToClipboard function

### DIFF
--- a/src/models/MediaImage.ts
+++ b/src/models/MediaImage.ts
@@ -46,6 +46,48 @@ export class MediaImageL {
     get app(): Maybe<CushyAppL> {return this.draft?.app} // prettier-ignore
     get script(): Maybe<CushyScriptL> {return this.app?.script } // prettier-ignore
 
+    copyToClipboard = async () => {
+        const canvas = document.createElement('canvas')
+        const ctx = canvas.getContext('2d')
+
+        const img = new Image()
+        img.src = URL.createObjectURL(this.getAsBlob())
+
+        img.onload = () => {
+            canvas.width = img.width
+            canvas.height = img.height
+            ctx?.drawImage(img, 0, 0)
+
+            const dataUrl = canvas.toDataURL('image/png')
+
+            /* Convert data URL to a Blob */
+            const binary = atob(dataUrl.split(',')[1])
+            const array = new Uint8Array(binary.length)
+            for (let i = 0; i < binary.length; i++) {
+                array[i] = binary.charCodeAt(i)
+            }
+
+            const converted = new Blob([array], { type: 'image/png' })
+
+            navigator.clipboard
+                .write([
+                    new ClipboardItem({
+                        'image/png': converted,
+                    }),
+                ])
+                .then(() => {
+                    console.log('Image copied to clipboard successfully')
+                })
+                .catch((error) => {
+                    console.error('Error copying image to clipboard:', error)
+                })
+        }
+
+        img.onerror = (error) => {
+            console.error('Error loading image:', error)
+        }
+    }
+
     useAsDraftIllustration = (draft_?: DraftL) => {
         const draft = draft_ ?? this.draft
         if (draft == null) return toastError(`no related draft found`)

--- a/src/models/MediaImage.ts
+++ b/src/models/MediaImage.ts
@@ -49,42 +49,39 @@ export class MediaImageL {
     /* XXX: This should only be a stop-gap for a custom solution that isn't hampered by the browser's security capabilities */
     /** Uses browser clipboard API to copy the image to clipboard, will only copy as a PNG and will not include metadata. */
     copyToClipboard = () => {
-        const canvas = document.createElement('canvas')
-        const ctx = canvas.getContext('2d')
+        createHTMLImage_fromURL(URL.createObjectURL(this.getAsBlob()))
+            .then((img) => {
+                const canvas = document.createElement('canvas')
+                const ctx = canvas.getContext('2d')
 
-        const img = new Image()
-        img.src = URL.createObjectURL(this.getAsBlob())
+                canvas.width = img.width
+                canvas.height = img.height
+                ctx?.drawImage(img, 0, 0)
 
-        img.onload = () => {
-            canvas.width = img.width
-            canvas.height = img.height
-            ctx?.drawImage(img, 0, 0)
-
-            canvas.toBlob((blob) => {
-                if (blob == null) {
-                    toastError(`Could not copy image to clipboard: ${blob}`)
-                    return
-                }
-                navigator.clipboard
-                    .write([
-                        new ClipboardItem({
-                            [blob.type]: blob,
-                        }),
-                    ])
-                    .then(() => {
-                        toastInfo('Image copied to clipboard!')
-                    })
-                    .catch((error) => {
-                        toastError(`Could not copy image to clipboard: ${error}`)
-                        console.error('Error copying image to clipboard:', error)
-                    })
+                canvas.toBlob((blob) => {
+                    if (blob == null) {
+                        toastError(`Could not copy image to clipboard: ${blob}`)
+                        return
+                    }
+                    navigator.clipboard
+                        .write([
+                            new ClipboardItem({
+                                [blob.type]: blob,
+                            }),
+                        ])
+                        .then(() => {
+                            toastInfo('Image copied to clipboard!')
+                        })
+                        .catch((error) => {
+                            toastError(`Could not copy image to clipboard: ${error}`)
+                            console.error('Error copying image to clipboard:', error)
+                        })
+                })
             })
-        }
-
-        img.onerror = (error) => {
-            toastError(`Could not copy image to clipboard: ${error}`)
-            console.error('Error loading image:', error)
-        }
+            .catch((error) => {
+                toastError(`Could not copy image to clipboard: ${error}`)
+                console.error('Error loading image:', error)
+            })
     }
 
     useAsDraftIllustration = (draft_?: DraftL) => {

--- a/src/panels/ImageDropdownUI.tsx
+++ b/src/panels/ImageDropdownUI.tsx
@@ -21,9 +21,9 @@ export const ImageDropdownMenuUI = observer(function ImageDropdownMenuUI_(p: { i
     const img = p.img
     return (
         <>
-            <div className='divider divider-start my-0'>send to</div>
+            <div className='divider divider-start my-1'>Send to</div>
             <MenuItem icon={<span class='material-symbols-outlined'>content_copy</span>} onClick={img.copyToClipboard}>
-                clipboard
+                Clipboard
             </MenuItem>
             <MenuItem
                 icon={<span className='material-symbols-outlined'>settings_overscan</span>}
@@ -31,7 +31,7 @@ export const ImageDropdownMenuUI = observer(function ImageDropdownMenuUI_(p: { i
                 onClick={() => st.layout.FOCUS_OR_CREATE('Image', { imageID: img.id })}
                 shortcut={'mod+click'}
             >
-                dedicated panel (ctrl+click)
+                Dedicated Panel
             </MenuItem>
             <MenuItem
                 icon={<span className='material-symbols-outlined'>center_focus_weak</span>}
@@ -39,7 +39,7 @@ export const ImageDropdownMenuUI = observer(function ImageDropdownMenuUI_(p: { i
                 shortcut={'shift+click'}
                 onClick={() => st.layout.FOCUS_OR_CREATE('Canvas', { imgID: img.id })}
             >
-                unified Canvas (shift+click)
+                Unified Canvas
             </MenuItem>
             <MenuItem
                 icon={<span className='material-symbols-outlined'>brush</span>}
@@ -47,16 +47,10 @@ export const ImageDropdownMenuUI = observer(function ImageDropdownMenuUI_(p: { i
                 shortcut={'alt+click'}
                 onClick={() => st.layout.FOCUS_OR_CREATE('Paint', { imgID: img.id })}
             >
-                MiniPaint (alt+click)
+                MiniPaint
             </MenuItem>
-            <MenuItem
-                icon={<span className='material-symbols-outlined text-red-500'>delete</span>}
-                disabled={!img?.absPath}
-                onClick={() => img.delete()}
-            >
-                delete
-            </MenuItem>
-            <div className='divider divider-start my-0'>FileSystem</div>
+
+            <div className='divider divider-start my-1'>FileSystem</div>
             <MenuItem
                 icon={<span className='material-symbols-outlined'>folder</span>}
                 // appearance='subtle'
@@ -66,7 +60,7 @@ export const ImageDropdownMenuUI = observer(function ImageDropdownMenuUI_(p: { i
                     showItemInFolder(img.absPath)
                 }}
             >
-                open folder
+                Open folder
             </MenuItem>
             {/* 3. OPEN FILE ITSELF */}
             <MenuItem
@@ -80,16 +74,23 @@ export const ImageDropdownMenuUI = observer(function ImageDropdownMenuUI_(p: { i
                     openExternal(imgPathWithFileProtocol)
                 }}
             >
-                open
+                Open
             </MenuItem>
-            <div className='divider divider-start my-0'>Draft</div>
+            <div className='divider divider-start my-1'>Draft</div>
             <MenuItem className='_MenuItem' onClick={() => img.useAsDraftIllustration()}>
                 <div className='flex items-center gap-2'>
                     <span className='material-symbols-outlined'>image</span>
-                    Use as draft illustration
+                    Use as Draft Illustration
                 </div>
             </MenuItem>
-            <div className='divider divider-start my-0'>send to</div>
+            <div className='divider divider-start my-0'></div>
+            <MenuItem
+                icon={<span className='material-symbols-outlined text-red-500'>delete</span>}
+                disabled={!img?.absPath}
+                onClick={() => img.delete()}
+            >
+                Delete
+            </MenuItem>
             <ImageActionMenu img={img} />
         </>
     )

--- a/src/panels/ImageDropdownUI.tsx
+++ b/src/panels/ImageDropdownUI.tsx
@@ -19,10 +19,17 @@ export const ImageDropdownUI = observer(function ImageDropdownUI_(p: { img: Medi
 export const ImageDropdownMenuUI = observer(function ImageDropdownMenuUI_(p: { img: MediaImageL }) {
     const st = useSt()
     const img = p.img
-
     return (
         <>
             <div className='divider divider-start my-0'>send to</div>
+            <MenuItem
+                icon={<span class='material-symbols-outlined'>content_copy</span>}
+                onClick={async () => {
+                    img.copyToClipboard()
+                }}
+            >
+                clipboard
+            </MenuItem>
             <MenuItem
                 icon={<span className='material-symbols-outlined'>settings_overscan</span>}
                 disabled={!img?.absPath}

--- a/src/panels/ImageDropdownUI.tsx
+++ b/src/panels/ImageDropdownUI.tsx
@@ -22,12 +22,7 @@ export const ImageDropdownMenuUI = observer(function ImageDropdownMenuUI_(p: { i
     return (
         <>
             <div className='divider divider-start my-0'>send to</div>
-            <MenuItem
-                icon={<span class='material-symbols-outlined'>content_copy</span>}
-                onClick={async () => {
-                    img.copyToClipboard()
-                }}
-            >
+            <MenuItem icon={<span class='material-symbols-outlined'>content_copy</span>} onClick={img.copyToClipboard}>
                 clipboard
             </MenuItem>
             <MenuItem


### PR DESCRIPTION
Also adds a button to "send to clipboard" in ImageDropdownUI
As far as I can tell, you can only put png/jpg's in the clipboard, so it must be converted always.
This more than likely won't keep any image metadata, but it's useful for quick sharing. Most chat applications scrub metadata nowadays anyways.