### PR TITLE
UI opt changes

### DIFF
--- a/library/built-in/CushyDiffusion.ts
+++ b/library/built-in/CushyDiffusion.ts
@@ -76,10 +76,6 @@ app({
         // MODEL, clip skip, vae, etc. ---------------------------------------------------------------
         let { ckpt, vae, clip } = run_model(ui.model)
 
-        if (ui.model.extra.rescale_cfg) {
-            ckpt = graph.RescaleCFG({ model: ckpt, multiplier: ui.model.extra.rescale_cfg.multiplier })
-        }
-
         // RICH PROMPT ENGINE -------- ---------------------------------------------------------------
         const posPrompt = run_prompt({
             prompt: ui.positive,

--- a/src/controls/FormBuilder.ts
+++ b/src/controls/FormBuilder.ts
@@ -131,6 +131,7 @@ export class FormBuilder {
             startCollapsed?: boolean
             // extra for optionality
             startActive?: boolean,
+            collapsible?: boolean,
             // ... plus every other config param
         },
         widgetFn: (config:T['$Input']) => T) {
@@ -139,6 +140,7 @@ export class FormBuilder {
             requirements: config.requirements,
             startActive: config.startActive,
             startCollapsed: config.startCollapsed,
+            collapsible: config.collapsible ?? true,
             widget: widgetFn({ ...config, startCollapsed: undefined }),
         })
     }

--- a/src/controls/builder/EnumBuilder.ts
+++ b/src/controls/builder/EnumBuilder.ts
@@ -15,7 +15,7 @@ export type IEnumBuilder = {
 
 export type IEnumBuilderOpt = {
     [K in keyof Requirable]: (
-        config: Omit<Widget_enum_config<Requirable[K]['$Value']>, 'enumName'> & { startActive?: boolean },
+        config: Omit<Widget_enum_config<Requirable[K]['$Value']>, 'enumName'> & { startActive?: boolean; collapsible?: boolean },
     ) => Spec<Widget_enum<Requirable[K]['$Value']>>
 }
 
@@ -41,6 +41,7 @@ export class EnumBuilderOpt {
                     form.builder.optional({
                         label: config.label,
                         startActive: config.startActive,
+                        collapsible: config.collapsible,
                         widget: new Spec('enum', /* form, */ { ...config, enumName }),
                     }),
             })

--- a/src/controls/widgets/enum/WidgetEnum.tsx
+++ b/src/controls/widgets/enum/WidgetEnum.tsx
@@ -35,7 +35,7 @@ export type Widget_enum_types<O> = {
 // STATE
 export interface Widget_enum<O> extends Widget_enum_types<O> {}
 export class Widget_enum<O> implements IWidget<Widget_enum_types<O>> {
-    readonly isCollapsible = false
+    readonly isCollapsible = this.config.collapsible ?? false
     readonly id: string
     readonly type: 'enum' = 'enum'
 

--- a/src/controls/widgets/optional/WidgetOptional.tsx
+++ b/src/controls/widgets/optional/WidgetOptional.tsx
@@ -10,6 +10,7 @@ import { WidgetDI } from '../WidgetUI.DI'
 // CONFIG
 export type Widget_optional_config<T extends Spec> = WidgetConfigFields<{
     startActive?: boolean
+    collapsible?: boolean
     widget: T
 }>
 
@@ -38,7 +39,7 @@ export class Widget_optional<T extends Spec> implements IWidget<Widget_optional_
         if (this.serial.active) return this.childOrThrow.serialHash
         return 'x'
     }
-    readonly isCollapsible = true
+    readonly isCollapsible = this.config.collapsible ?? true
     readonly id: string
     readonly type: 'optional' = 'optional'
 
@@ -57,20 +58,10 @@ export class Widget_optional<T extends Spec> implements IWidget<Widget_optional_
 
     setOn = () => {
         this.serial.active = true
-        const unmounted = this.config.widget
-        const prevSerial = this.serial.child
-        if (prevSerial && unmounted.type === prevSerial.type) {
-            this.child = this.form.builder._HYDRATE(unmounted, prevSerial)
-        } else {
-            this.child = this.form.builder._HYDRATE(unmounted, null)
-            this.serial.child = this.child.serial
-        }
     }
 
     setOff = () => {
         this.serial.active = false
-        this.child = undefined
-        // this.serial.child = undefined
     }
 
     constructor(public form: Form<any>, public config: Widget_optional_config<T>, serial?: Widget_optional_serial<T>) {
@@ -84,6 +75,16 @@ export class Widget_optional<T extends Spec> implements IWidget<Widget_optional_
         }
         const isActive = serial?.active ?? defaultActive
         if (isActive) this.setOn()
+
+        const unmounted = this.config.widget
+        const prevSerial = this.serial.child
+        if (prevSerial && unmounted.type === prevSerial.type) {
+            this.child = this.form.builder._HYDRATE(unmounted, prevSerial)
+        } else {
+            this.child = this.form.builder._HYDRATE(unmounted, null)
+            this.serial.child = this.child.serial
+        }
+
         makeObservable(this, {
             serial: observable,
             value: computed,

--- a/src/controls/widgets/optional/WidgetOptionalUI.tsx
+++ b/src/controls/widgets/optional/WidgetOptionalUI.tsx
@@ -8,20 +8,33 @@ import { WidgetWithLabelUI } from 'src/controls/shared/WidgetWithLabelUI'
 
 export const WidgetOptional_LineUI = observer(function WidgetBoolUI_<T extends Spec>(p: { widget: Widget_optional<T> }) {
     const WidgetUI = WidgetDI.WidgetUI
-    if (!p.widget.serial.active) return null
+    // if (!p.widget.serial.active) return null
     if (p.widget.child == null) return <>❌ ERROR: optional is active but no widget❓</>
     if (p.widget.child?.serial.collapsed) return <WidgetWithLabelUI rootKey={'_'} widget={p.widget.child} />
     const { WidgetLineUI } = WidgetUI(p.widget.child)
     if (WidgetLineUI == null) return null
-    return <WidgetLineUI widget={p.widget.child} />
+
+    return (
+        <div /* Shows if active or not. */
+            tw={['flex w-full gap-0.5 items-center ', 'select-none outline-none', !p.widget.serial.active && 'brightness-50']}
+        >
+            <WidgetLineUI widget={p.widget.child} />
+        </div>
+    )
 })
 
 export const WidgetOptional_BlockUI = observer(function WidgetBoolUI_<T extends Spec>(p: { widget: Widget_optional<T> }) {
     const WidgetUI = WidgetDI.WidgetUI
-    if (!p.widget.serial.active) return null
+    // if (!p.widget.serial.active) return null
     if (p.widget.child == null) return <>❌ ERROR: optional is active but no widget❓</>
     if (p.widget.child?.serial.collapsed) return <WidgetWithLabelUI rootKey={'_'} widget={p.widget.child} />
     const { WidgetBlockUI } = WidgetUI(p.widget.child)
     if (WidgetBlockUI == null) return null
-    return <WidgetBlockUI widget={p.widget.child} />
+    return (
+        <div /* Shows if active or not. */
+            tw={['flex w-full gap-0.5 items-center', 'select-none outline-none', !p.widget.serial.active && 'brightness-50']}
+        >
+            <WidgetBlockUI widget={p.widget.child} />
+        </div>
+    )
 })


### PR DESCRIPTION
Very Very WIP
- Remove borders and collapse button for Optionals that aren't groups, so basically everything but groupOpt.
- Moves the checkmark to the right, use the new checkmark styling. Padding between label and checkmarks.
- Optionals will now always show their content, and just dim it instead.
- Fixes rescaleCFG being outside of prefab_model
- Makes the checkboxes (for only the Opts right now) do the drag to activate/deactivate multiple if you start on one checkbox and then hold left mouse and drag on to another.


TODO list/Broken things I've noticed on a quick glance. I will/maintainer can edit this if there's more things I broke.

- [ ] Make inactive Blocks look better. Not sure how I want to approach this yet, but just dimming the elements looks fairly bad.
- [ ] SizeWidget in the latent prefab uses the new padding for non-group Opts when it shouldn't