### PR TITLE
UI: Fix SelectUI Visually (selectMany/searchEnum)

### DIFF
--- a/src/controls/widgets/choices/WidgetChoicesUI.tsx
+++ b/src/controls/widgets/choices/WidgetChoicesUI.tsx
@@ -138,7 +138,7 @@ export const WidgetChoices_SelectLineUI = observer(function WidgetChoices_Select
                     <div tw='flex flex-1 justify-between'>
                         <div tw='flex-1'>{v.key}</div>
                         {/* 👇 TODO: clean this */}
-                        {v.key in widget.serial.values_ && (
+                        {/* {v.key in widget.serial.values_ && (
                             <div
                                 tw='btn btn-square btn-sm'
                                 onClick={(ev) => {
@@ -148,7 +148,7 @@ export const WidgetChoices_SelectLineUI = observer(function WidgetChoices_Select
                             >
                                 <span className='material-symbols-outlined'>delete</span>
                             </div>
-                        )}
+                        )} */}
                     </div>
                 )}
                 equalityCheck={(a, b) => a.key === b.key}

--- a/src/controls/widgets/enum/WidgetEnumUI.tsx
+++ b/src/controls/widgets/enum/WidgetEnumUI.tsx
@@ -59,15 +59,7 @@ export const EnumSelectorUI = observer(function EnumSelectorUI_(p: {
     const value = p.value()
     const hasError = Boolean(value.isSubstitute || value.ENUM_HAS_NO_VALUES)
     return (
-        <div
-            tw={[
-                'flex flex-1 rounded h-full overflow-clip text-shadow',
-                'border border-base-100 hover:brightness-110',
-                'hover:border-base-200',
-                'bg-primary/20 border-1',
-                'border-b-2 border-b-base-200 hover:border-b-base-300',
-            ]}
-        >
+        <div tw={['w-full h-full']}>
             <SelectUI //
                 tw={[{ ['rsx-field-error']: hasError }]}
                 size='sm'

--- a/src/controls/widgets/number/InputNumberUI.tsx
+++ b/src/controls/widgets/number/InputNumberUI.tsx
@@ -178,8 +178,9 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
         <div /* Root */
             className={p.className}
             tw={[
+                'WIDGET-FIELD',
                 'input-number-ui custom-roundness',
-                'h-7 flex-1 select-none min-w-16 cursor-ew-resize overflow-clip',
+                'flex-1 select-none min-w-16 cursor-ew-resize overflow-clip',
                 'bg-primary/30 border border-base-100 border-b-2 border-b-base-200',
                 !isEditing && 'hover:border-base-200 hover:border-b-base-300 hover:bg-primary/40',
             ]}

--- a/src/controls/widgets/selectMany/WidgetSelectManyUI.tsx
+++ b/src/controls/widgets/selectMany/WidgetSelectManyUI.tsx
@@ -14,6 +14,7 @@ export const WidgetSelectManyUI = observer(function WidgetSelectOneUI_<T extends
             size='sm'
             multiple
             getLabelText={(t) => t.label ?? t.id}
+            getLabelUI={(t) => t.label ?? t.id}
             options={() => widget.choices}
             value={() => widget.serial.values}
             onChange={(selectOption) => widget.toggleItem(selectOption)}

--- a/src/rsuite/SelectUI.tsx
+++ b/src/rsuite/SelectUI.tsx
@@ -83,7 +83,7 @@ class AutoCompleteSelectState<T> {
                     : value.map((i) => {
                           const label = this.p.getLabelText(i)
                           return (
-                              <div key={label} tw='badge badge-primary'>
+                              <div key={label} tw='badge badge-primary text-shadow-inv'>
                                   {label}
                               </div>
                           )
@@ -210,8 +210,16 @@ export const SelectUI = observer(function SelectUI_<T>(p: SelectProps<T>) {
     const st = useSt()
     const s = useMemo(() => new AutoCompleteSelectState(st, p), [])
     return (
-        <div
-            tw='flex flex-1 items-center h-full p-0.5 relative'
+        <div /* Container/Root */
+            tw={[
+                'WIDGET-FIELD',
+                'flex flex-1 items-center p-0.5 relative',
+                'rounded overflow-clip text-shadow',
+                'border border-base-100 hover:brightness-110',
+                'hover:border-base-200',
+                'bg-primary/20 border-1',
+                'border-b-2 border-b-base-200 hover:border-b-base-300',
+            ]}
             className={p.className}
             ref={s.anchorRef}
             onKeyUp={s.onRealInputKeyUp}
@@ -222,11 +230,16 @@ export const SelectUI = observer(function SelectUI_<T>(p: SelectProps<T>) {
             onBlur={s.onBlur}
             style={{ background: s.searchQuery === '' ? 'none' : undefined }}
         >
-            <div className='flex-1'>
+            <div className='flex-1 h-full '>
                 {/* ANCHOR */}
                 <div //
                     tabIndex={-1}
-                    tw='input input-xs text-sm flex items-center gap-1 bg-transparent p-0 select-none pointer-events-none'
+                    tw={[
+                        'input input-xs text-sm',
+                        'flex items-center gap-1',
+                        'p-0 h-full bg-transparent',
+                        'select-none pointer-events-none overflow-clip',
+                    ]}
                 >
                     {s.isOpen ? (
                         <></>
@@ -242,10 +255,10 @@ export const SelectUI = observer(function SelectUI_<T>(p: SelectProps<T>) {
                         </>
                     )}
                 </div>
-                <div tw='absolute top-0 left-0 right-0 z-100 '>
+                <div tw='absolute top-0 left-0 right-0 z-100 h-full'>
                     <input
                         //
-                        tw='input input-sm w-full'
+                        tw='input input-sm w-full h-full !outline-none'
                         type='text'
                         value={s.searchQuery}
                         onChange={() => {}}
@@ -295,29 +308,34 @@ export const SelectPopupUI = observer(function SelectPopupUI_<T>(p: { s: AutoCom
                             }`}
                             tw={[
                                 'flex items-center gap-1 rounded',
-                                isSelected && 'bg-primary text-primary-content hover:text-neutral-content text-shadow-inv',
+                                'h-full',
+                                isSelected &&
+                                    'bg-primary text-primary-content hover:text-neutral-content text-shadow-inv active:bg-primary',
                             ]}
                             onMouseEnter={(ev) => {
                                 s.setNavigationIndex(index)
                             }}
                             onMouseDown={(ev) => s.onMenuEntryClick(ev, index)}
                         >
-                            <div tw={'rounded py-3 h-6'}>
+                            <div tw={'rounded flex pl-1'}>
                                 {s.isMultiSelect ? (
                                     <input
-                                        onChange={() => {}}
-                                        checked={isSelected}
                                         type='checkbox'
-                                        tw='checkbox checkbox-primary checkbox-sm input-xs bg-none'
+                                        checked={isSelected}
+                                        tw={['flex-1 checkbox checkbox-primary w-5 h-5']}
+                                        tabIndex={-1}
+                                        readOnly
                                     />
                                 ) : (
                                     <></>
                                 )}
                             </div>
                             {/* {isSelected ? '🟢' : null} */}
-                            {s.p.getLabelUI //
-                                ? s.p.getLabelUI(option)
-                                : s.p.getLabelText(option)}
+                            <div tw='flex h-full w-full items-center' style={{ height: '28px' }}>
+                                {s.p.getLabelUI //
+                                    ? s.p.getLabelUI(option)
+                                    : s.p.getLabelText(option)}
+                            </div>
                         </li>
                     )
                 })}

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -1,6 +1,6 @@
 #root {
     --roundness: 5px;
-    --input-height: 32px;
+    --input-height: 28px;
 }
 
 .WIDGET-FIELD {

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -1,5 +1,10 @@
 #root {
     --roundness: 5px;
+    --input-height: 32px;
+}
+
+.WIDGET-FIELD {
+    height: var(--input-height);
 }
 
 .custom-roundness {


### PR DESCRIPTION
This only fixes the UI itself, not the underlying functionality. Makes it looks like how searchEnum looked, by moving most the changes I made there to this file instead.
- Added a WIDGET-FIELD class to theme.css, to make all the input widgets have a consistent height in the future
- Use the new checkbox styling
- InputNumberUI now uses the WIDGET-FIELD class