### PR TITLE
UI: Improve SizeWidgetUI, fix InputNumberUI, overhaul SeedWidgetUI

### DIFF
--- a/library/built-in/_prefabs/prefab_latent_v3.ts
+++ b/library/built-in/_prefabs/prefab_latent_v3.ts
@@ -12,11 +12,13 @@ export const ui_latent_v3 = () => {
         items: {
             emptyLatent: form.group({
                 awaysExpanded: true,
+                neverBordered: true,
                 label: false,
-                items: { batchSize, size: form.size({ label: false }) },
+                items: { batchSize, size: form.size({ label: false, awaysExpanded: true, neverBordered: true }) },
             }),
             image: form.group({
                 awaysExpanded: true,
+                neverBordered: true,
                 label: false,
                 items: { batchSize, image: form.image() },
             }),

--- a/src/controls/widgets/number/InputNumberUI.tsx
+++ b/src/controls/widgets/number/InputNumberUI.tsx
@@ -172,8 +172,6 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
         }
     }
 
-    const buttonSize = 4
-
     return (
         <div /* Root */
             className={p.className}
@@ -189,7 +187,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                 <button /* Left Button */
                     tw={[
                         'h-full absolute left-0 rounded-none pr-0.5',
-                        `!w-${buttonSize} pb-1 leading-none border border-base-200 opacity-0 bg-base-200 hover:brightness-125`,
+                        `w-4 pb-0.5 leading-none border border-base-200 opacity-0 bg-base-200 hover:brightness-125`,
                     ]}
                     style={{ zIndex: 2 }}
                     onClick={(_) => {
@@ -205,7 +203,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                     tw={[!p.hideSlider && !isEditing && 'bg-primary/40']}
                     style={{ width: `${((val - rangeMin) / (rangeMax - rangeMin)) * 100}%` }}
                 />
-                <div tw='absolute flex w-full h-full px-1'>
+                <div tw='absolute flex w-full h-full px-2'>
                     <div
                         tw={['relative flex flex-1 select-none']}
                         onWheel={(ev) => {
@@ -247,9 +245,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                             })
                         }}
                     >
-                        <div /* Text Container */
-                            tw={[`custom-roundness flex-auto flex items-center !px-${buttonSize} text-sm text-shadow`]}
-                        >
+                        <div /* Text Container */ tw={[`custom-roundness flex-auto flex items-center px-3 text-sm text-shadow`]}>
                             {!isEditing && p.text ? (
                                 <div /* Inner Label Text - Not shown while editing */
                                     tw={['outline-0 border-0 border-transparent z-10 w-full text-left']}
@@ -331,7 +327,7 @@ export const InputNumberUI = observer(function InputNumberUI_(p: {
                 <button /* Right Button */
                     tw={[
                         'h-full absolute right-0 pl-0.5',
-                        `!w-${buttonSize} pb-1 leading-none border border-base-200 opacity-0 bg-base-200 hover:brightness-125`,
+                        `w-4 pb-0.5 leading-none border border-base-200 opacity-0 bg-base-200 hover:brightness-125`,
                     ]}
                     style={{ zIndex: 2 }}
                     onClick={(_) => {

--- a/src/controls/widgets/seed/WidgetSeedUI.tsx
+++ b/src/controls/widgets/seed/WidgetSeedUI.tsx
@@ -2,76 +2,124 @@ import type { Widget_seed } from './WidgetSeed'
 
 import { observer } from 'mobx-react-lite'
 
-import { Button, InputNumberBase } from 'src/rsuite/shims'
+import { Button } from 'src/rsuite/shims'
+import { InputNumberUI } from '../number/InputNumberUI'
+
+let isDragging = false
 
 export const WidgetSeedUI = observer(function WidgetSeedUI_(p: { widget: Widget_seed }) {
     const widget = p.widget
     const val = widget.serial.val
-    return (
-        <div tw='flex-1 flex items-center join virtualBorder'>
-            <button
-                type='button'
-                tw={['flex-1 whitespace-nowrap join-item btn-sm btn-ghost', widget.serial.mode === 'randomize' && 'btn-active']}
-                onClick={() => {
-                    widget.serial.mode = 'randomize'
-                    widget.serial.active = true
-                }}
-            >
-                🎲 Rand
-            </button>
-            <button
-                type='button'
-                tw={['flex-1 whitespace-nowrap join-item btn-sm btn-ghost', widget.serial.mode === 'fixed' && 'btn-active']}
-                onClick={() => {
-                    widget.serial.mode = 'fixed'
-                    widget.serial.active = true
-                    // req.state.val = Math.floor(Math.random() * 1000000)
-                }}
-            >
-                💎 Fixed
-            </button>
-            <InputNumberBase //
-                _size='sm'
-                style={{
-                    fontFamily: 'monospace',
-                    width: val.toString().length + 6 + 'ch',
-                }}
-                className='input-sm'
-                disabled={!(widget.serial.mode !== 'randomize' || !widget.serial.active)}
-                value={val}
-                min={widget.config.min}
-                max={widget.config.max}
-                step={1}
-                onChange={(ev) => {
-                    const next = ev.target.value
-                    // parse value
-                    let num =
-                        typeof next === 'string' //
-                            ? parseInt(next, 10)
-                            : next
 
-                    // ensure is a number
-                    if (isNaN(num) || typeof num != 'number') {
-                        return console.log(`${JSON.stringify(next)} is not a number`)
-                    }
-                    // ensure ints are ints
-                    num = Math.round(num)
-                    widget.serial.val = num
-                }}
-            />
-            <Button
-                size='sm'
-                appearance='subtle'
-                onClick={() => {
-                    widget.serial.mode = 'fixed'
-                    widget.serial.active = true
-                    widget.serial.val = Math.floor(Math.random() * 1000000)
-                }}
-                icon={<span className='material-symbols-outlined'>autorenew</span>}
+    const isDraggingListener = (ev: MouseEvent) => {
+        if (ev.button == 0) {
+            isDragging = false
+            window.removeEventListener('mouseup', isDraggingListener, true)
+        }
+    }
+
+    return (
+        <>
+            <div
+                tw={[
+                    'WIDGET-FIELD',
+                    'flex-1 flex items-center join',
+                    'rounded overflow-clip text-shadow',
+                    'border border-base-200 hover:border-base-200',
+                    'bg-primary/5',
+                    'border-b-2 border-b-base-200 hover:border-b-base-300',
+                    '!outline-none',
+                ]}
             >
-                New
-                {/* Random */}
-            </Button>
-        </div>
+                <button
+                    type='button'
+                    tw={[
+                        'flex items-center gap-1 whitespace-nowrap join-item btn-sm btn-ghost text-shadow px-2',
+                        'bg-base-200 hover:bg-base-200 hover:brightness-110',
+                        'border-0 !outline-none',
+                        widget.serial.mode === 'randomize' && 'btn-active !bg-primary text-shadow-inv text-primary-content',
+                    ]}
+                    onMouseDown={(ev) => {
+                        if (ev.button == 0) {
+                            widget.serial.mode = 'randomize'
+                            widget.serial.active = true
+                            isDragging = true
+                            window.addEventListener('mouseup', isDraggingListener, true)
+                        }
+                    }}
+                    onMouseEnter={(ev) => {
+                        if (isDragging) {
+                            widget.serial.mode = 'randomize'
+                            widget.serial.active = true
+                        }
+                    }}
+                >
+                    <span className='material-symbols-outlined'>shuffle</span>
+                    <div>Random</div>
+                </button>
+                <button
+                    type='button'
+                    tw={[
+                        'flex items-center gap-1 flex-shrink whitespace-nowrap join-item btn-sm btn-ghost text-shadow px-2',
+                        'bg-base-200 hover:bg-base-200 hover:brightness-110',
+                        'border-0 !outline-none',
+                        widget.serial.mode === 'fixed' && 'btn-active !bg-primary text-shadow-inv text-primary-content',
+                    ]}
+                    onMouseDown={(ev) => {
+                        if (ev.button == 0) {
+                            widget.serial.mode = 'fixed'
+                            widget.serial.active = true
+                            isDragging = true
+                            window.addEventListener('mouseup', isDraggingListener, true)
+                        }
+                    }}
+                    onMouseEnter={(ev) => {
+                        if (isDragging) {
+                            widget.serial.mode = 'fixed'
+                            widget.serial.active = true
+                        }
+                    }}
+                >
+                    <span className='material-symbols-outlined'>input</span>
+                    <div>Fixed</div>
+                </button>
+                <div tw={['flex-1', widget.serial.mode == 'randomize' && 'pointer-events-none opacity-25']}>
+                    <InputNumberUI
+                        tw={'!border-none join-item'}
+                        min={widget.config.min}
+                        max={widget.config.max}
+                        step={1}
+                        value={val}
+                        mode='int'
+                        onValueChange={(value) => {
+                            widget.serial.val = value
+                        }}
+                    />
+                </div>
+                <Button
+                    tw={'flex w-7 !outline-none'}
+                    size='sm'
+                    appearance='subtle'
+                    onClick={() => {
+                        widget.serial.mode = 'fixed'
+                        widget.serial.active = true
+                        widget.serial.val = Math.floor(Math.random() * 1000000)
+                    }}
+                    icon={
+                        <span tw='flex-1 pt-0.5' className='material-symbols-outlined'>
+                            autorenew
+                        </span>
+                    }
+                ></Button>
+            </div>
+            <div // Invisible undo button to make the widget line up with everything else neatly.
+                tw='opacity-0 cursor-default'
+                // tw={[widget.isChanged ? undefined : 'btn-disabled opacity-50']}
+                // onClick={() => widget.reset()}
+                className='btn btn-xs btn-narrower btn-ghost'
+            >
+                <span className='material-symbols-outlined'>undo</span>
+            </div>
+        </>
     )
 })

--- a/src/controls/widgets/size/WidgetSizeUI.tsx
+++ b/src/controls/widgets/size/WidgetSizeUI.tsx
@@ -20,65 +20,100 @@ export const WidgetSizeX_LineUI = observer(function WidgetSize_LineUI_(p: {
     bounds?: { min?: number; max?: number; step?: number }
 }) {
     const uist = p.sizeHelper
+    const ratioDisplaySize = 26
 
     return (
         <div className='flex flex-1 flex-col gap-1'>
             <div tw='flex items-center gap-1'>
-                <div tw='virtualBorder' style={{ width: '2rem', height: '2rem' }}>
-                    <div
-                        tw='bg-primary'
-                        style={{
-                            //
-                            width: uist.height < uist.width ? '2rem' : `${(uist.width / uist.height) * 2}rem`,
-                            height: uist.height < uist.width ? `${(uist.height / uist.width) * 2}rem` : '2rem',
-                        }}
-                    ></div>
-                </div>
-                <InputNumberUI
-                    //
-                    min={p.bounds?.min ?? 128}
-                    max={p.bounds?.max ?? 4096}
-                    step={p.bounds?.step ?? 32}
-                    mode='int'
-                    tw='join-item'
-                    value={uist.width}
-                    hideSlider
-                    onValueChange={(next) => uist.setWidth(next)}
-                    forceSnap={true}
-                    text='Width'
-                    suffix='px'
-                />
-                <InputNumberUI
-                    //
-                    tw='join-item'
-                    min={p.bounds?.min ?? 128}
-                    max={p.bounds?.max ?? 4096}
-                    step={p.bounds?.step ?? 32}
-                    hideSlider
-                    mode='int'
-                    value={uist.height}
-                    onValueChange={(next) => uist.setHeight(next)}
-                    forceSnap={true}
-                    text='Height'
-                    suffix='px'
-                />
-                <button // Aspect Lock button
-                    tw={['btn btn-xs', uist.isAspectRatioLocked && 'bg-primary hover:bg-primary text-primary-content']}
-                    onClick={(ev) => {
-                        uist.isAspectRatioLocked = !uist.isAspectRatioLocked
-                        if (!uist.isAspectRatioLocked) {
-                            return
-                        }
-                        /* Need to snap value if linked */
-                        if (uist.wasHeightAdjustedLast) {
-                            uist.setHeight(uist.height)
-                        } else {
-                            uist.setWidth(uist.width)
-                        }
-                    }}
+                <div // Extra div because gap-1 will eat in to the child's width for SOME reason
                 >
-                    <span className='material-symbols-outlined'>{uist.isAspectRatioLocked ? 'link' : 'link_off'}</span>
-                </button>
+                    <div // Aspect ratio display background
+                        tw={[
+                            //
+                            'flex rounded-sm virtualBorder bg-base-300',
+                            'overflow-clip',
+                            'items-center justify-center',
+                        ]}
+                        style={{ width: `${ratioDisplaySize}px`, height: `${ratioDisplaySize}px` }}
+                    >
+                        <div // Aspect ratio display foreground
+                            tw='relative bg-primary'
+                            style={{
+                                //
+                                width: '100%',
+                                height: '100%',
+                                // Use transform here because it works with floats and will not cause popping/mis-alignments.
+                                transform: `
+                                scaleX(${
+                                    uist.width < uist.height
+                                        ? Math.round((uist.width / uist.height) * ratioDisplaySize) / ratioDisplaySize
+                                        : '1'
+                                })
+                                scaleY(${
+                                    uist.height < uist.width
+                                        ? Math.round((uist.height / uist.width) * ratioDisplaySize) / ratioDisplaySize
+                                        : '1'
+                                })`,
+                            }}
+                        ></div>
+                    </div>
+                </div>
+                <div //Joined container
+                    tw={[
+                        'WIDGET-FIELD w-full h-full flex items-center join rounded gap-0.5 overflow-clip',
+                        'border border-base-100 border-b-base-200',
+                        'border-b-2 hover:border-base-200 hover:border-b-base-300',
+                    ]}
+                >
+                    <InputNumberUI
+                        //
+                        min={p.bounds?.min ?? 128}
+                        max={p.bounds?.max ?? 4096}
+                        step={p.bounds?.step ?? 32}
+                        mode='int'
+                        tw='join-item !border-none'
+                        value={uist.width}
+                        hideSlider
+                        onValueChange={(next) => uist.setWidth(next)}
+                        forceSnap={true}
+                        text='Width'
+                        suffix='px'
+                    />
+                    <InputNumberUI
+                        //
+                        tw='join-item !border-none'
+                        min={p.bounds?.min ?? 128}
+                        max={p.bounds?.max ?? 4096}
+                        step={p.bounds?.step ?? 32}
+                        hideSlider
+                        mode='int'
+                        value={uist.height}
+                        onValueChange={(next) => uist.setHeight(next)}
+                        forceSnap={true}
+                        text='Height'
+                        suffix='px'
+                    />
+                    <button // Aspect Lock button
+                        tw={[
+                            'btn btn-xs h-8 rounded-none join-item !border-none !outline-none',
+                            uist.isAspectRatioLocked && 'bg-primary hover:bg-primary text-primary-content !border-none',
+                        ]}
+                        onClick={(ev) => {
+                            uist.isAspectRatioLocked = !uist.isAspectRatioLocked
+                            if (!uist.isAspectRatioLocked) {
+                                return
+                            }
+                            // Need to snap value if linked
+                            if (uist.wasHeightAdjustedLast) {
+                                uist.setHeight(uist.height)
+                            } else {
+                                uist.setWidth(uist.width)
+                            }
+                        }}
+                    >
+                        <span className='material-symbols-outlined'>{uist.isAspectRatioLocked ? 'link' : 'link_off'}</span>
+                    </button>
+                </div>
             </div>
         </div>
     )
@@ -111,7 +146,7 @@ export const WigetSizeXUI = observer(function WigetSizeXUI_(p: {
     )
 
     return (
-        <div className='flex flex-col gap-1 bg-base-300 p-1 rounded-b'>
+        <div className='flex flex-col gap-1 bg-base-300 p-1 mt-0.5 rounded-b'>
             <div tw='flex items-start gap-2'>
                 <Joined>
                     {modelBtn('1.5')}

--- a/src/panels/router/Layout.tsx
+++ b/src/panels/router/Layout.tsx
@@ -112,6 +112,14 @@ export class CushyLayoutManager {
         console.log('[💠] Rendering Layout')
         return (
             <Layout //
+                onAuxMouseClick={(node, event) => {
+                    // Middle Mouse to close tab
+                    if (event.button == 1 && node instanceof FL.TabNode) {
+                        if (node.isEnableClose()) {
+                            this.closeTab(node.getId())
+                        }
+                    }
+                }}
                 onModelChange={(model) => {
                     runInAction(() => {
                         this.currentTabSet = model.getActiveTabset()

--- a/src/widgets/galleries/ImageUI.tsx
+++ b/src/widgets/galleries/ImageUI.tsx
@@ -35,6 +35,14 @@ export const ImageUI = observer(function ImageUI_(p: {
                 opacity,
                 borderRadius: '.5rem',
             }}
+            onMouseDown={(ev) => {
+                // Middle Mouse
+                if (ev.button == 1) {
+                    ev.stopPropagation()
+                    ev.preventDefault()
+                    return st.layout.FOCUS_OR_CREATE('Image', { imageID: image.id })
+                }
+            }}
             onClick={(ev) => {
                 if (hasMod(ev)) {
                     ev.stopPropagation()


### PR DESCRIPTION
RIP I'm tired, first commit is for WidgetSizeUI

WidgetSizeUI
- Made the aspect ratio display centered and darker background
- Use join/join-item to connect width/height/aspect ratio lock
- Update the latent_v3 prefab to get rid of borders
- Slight CSS tweaks

InputNumberUI
- Fix padding

WidgetSeedUI
- Make buttons similar colors to other newer buttons
- Make consistent size
- Use InputNumberUI instead of InputNumberBase
- Use icons instead of emoji
- Slight CSS tweaks

Misc
- Middle mouse closes tab
- Middle mouse opens image in a dedicated panel