### PR TITLE
UI: Overhaul Boolean widget, Improve SelectUI/Panel UX

### DIFF
--- a/src/controls/shared/Widget_ToggleUI.tsx
+++ b/src/controls/shared/Widget_ToggleUI.tsx
@@ -5,44 +5,19 @@ import { runInAction } from 'mobx'
 import { observer } from 'mobx-react-lite'
 
 import { isWidgetOptional } from '../widgets/WidgetUI.DI'
-
-let isDragging = false
-let wasEnabled = false
+import { InputBoolUI } from '../widgets/bool/InputBoolUI'
 
 export const Widget_ToggleUI = observer(function Widget_ToggleUI_(p: { widget: IWidget }) {
     if (!isWidgetOptional(p.widget)) return null
     const widget = p.widget as Widget_optional
 
-    const isActive = widget.serial.active
-    const isDraggingListener = (ev: MouseEvent) => {
-        if (ev.button == 0) {
-            isDragging = false
-            window.removeEventListener('mouseup', isDraggingListener, true)
-        }
-    }
-
     return (
-        <input
-            type='checkbox'
-            checked={isActive}
-            tw='checkbox checkbox-primary'
-            tabIndex={-1}
-            onMouseDown={(ev) => {
-                if (ev.button == 0) {
-                    runInAction(() => {
-                        ev.stopPropagation()
-                        widget.toggleAndUpdateChildCollapsedState()
-                    })
-                    isDragging = true
-                    wasEnabled = !isActive
-                    window.addEventListener('mouseup', isDraggingListener, true)
-                }
+        <InputBoolUI
+            active={widget.serial.active}
+            expand={false}
+            onValueChange={(value) => {
+                widget.serial.active = value
             }}
-            onMouseEnter={(ev) => {
-                if (isDragging) {
-                    wasEnabled ? widget.setOn() : widget.setOff()
-                }
-            }}
-        />
+        ></InputBoolUI>
     )
 })

--- a/src/controls/shared/Widget_ToggleUI.tsx
+++ b/src/controls/shared/Widget_ToggleUI.tsx
@@ -17,6 +17,7 @@ export const Widget_ToggleUI = observer(function Widget_ToggleUI_(p: { widget: I
             expand={false}
             onValueChange={(value) => {
                 widget.serial.active = value
+                widget.UpdateChildCollapsedState()
             }}
         ></InputBoolUI>
     )

--- a/src/controls/widgets/bool/InputBoolUI.tsx
+++ b/src/controls/widgets/bool/InputBoolUI.tsx
@@ -1,0 +1,107 @@
+import { runInAction } from 'mobx'
+import { observer } from 'mobx-react-lite'
+
+const clamp = (x: number, min: number, max: number) => Math.max(min, Math.min(max, x))
+
+let isDragging = false
+let wasEnabled = false
+
+export const InputBoolUI = observer(function InputBoolUI_(p: {
+    active?: Maybe<boolean>
+    display?: 'check' | 'button'
+    expand?: boolean
+    icon?: string
+    text?: string
+    onValueChange: (next: boolean) => void
+}) {
+    const isActive = p.active ?? false
+    const display = p.display ?? 'check'
+    const expand = p.expand
+    const icon = p.icon
+    const label = p.text
+
+    const isDraggingListener = (ev: MouseEvent) => {
+        if (ev.button == 0) {
+            isDragging = false
+            window.removeEventListener('mouseup', isDraggingListener, true)
+        }
+    }
+
+    return (
+        <div // Container
+            tw={[
+                'WIDGET-FIELD select-none',
+                'flex items-center',
+                '!outline-none',
+                'hover:brightness-110',
+                isActive && 'brightness-110',
+                // Make the click-able area take up the entire width when as a checkmark and haven't explicitly set expand to false.
+                ((display == 'check' && expand === undefined) || expand) && 'w-full',
+            ]}
+            tabIndex={-1}
+            onMouseDown={(ev) => {
+                if (ev.button == 0) {
+                    p.onValueChange(!isActive)
+                    ev.stopPropagation()
+
+                    wasEnabled = !isActive
+                    isDragging = true
+                    window.addEventListener('mouseup', isDraggingListener, true)
+                }
+            }}
+            onMouseEnter={(ev) => {
+                if (isDragging) {
+                    p.onValueChange(wasEnabled)
+                }
+            }}
+        >
+            {display == 'check' ? (
+                <>
+                    <div
+                        tw={[
+                            //
+                            'flex items-center rounded-sm bg-base-100',
+                            'border border-base-200',
+                            'border-b-2 border-b-base-300 box-content',
+                        ]}
+                    >
+                        <input
+                            type='checkbox'
+                            checked={isActive}
+                            tw={['checkbox checkbox-primary h-5 w-5 rounded-sm !outline-none cursor-default']}
+                            tabIndex={-1}
+                            readOnly
+                        />
+                    </div>
+                    {icon && (
+                        <span tw='pl-1.5' className='material-symbols-outlined'>
+                            {icon}
+                        </span>
+                    )}
+                    {label && <div tw={[icon ? 'pl-1' : 'pl-1.5']}>{label}</div>}
+                </>
+            ) : (
+                <>
+                    <div
+                        tw={[
+                            //
+                            'flex items-center h-full p-1 px-2 rounded',
+                            'bg-base-200 border border-base-100 text-shadow',
+                            'border-b-2 border-b-base-300',
+                            isActive && 'bg-primary text-primary-content text-shadow-inv',
+                            icon && 'pl-1.5',
+                            expand && 'w-full justify-center',
+                        ]}
+                    >
+                        {icon && (
+                            <span tw='flex-shrink-0 h-full pr-1.5 shadow-inherit' className='material-symbols-outlined'>
+                                {icon}
+                            </span>
+                        )}
+                        <p tw='w-full text-center line-clamp-1'>{label ? label : <></>}</p>
+                    </div>
+                </>
+            )}
+        </div>
+    )
+})

--- a/src/controls/widgets/bool/InputBoolUI.tsx
+++ b/src/controls/widgets/bool/InputBoolUI.tsx
@@ -12,7 +12,7 @@ export const InputBoolUI = observer(function InputBoolUI_(p: {
     expand?: boolean
     icon?: string
     text?: string
-    onValueChange: (next: boolean) => void
+    onValueChange?: (next: boolean) => void
 }) {
     const isActive = p.active ?? false
     const display = p.display ?? 'check'
@@ -41,16 +41,24 @@ export const InputBoolUI = observer(function InputBoolUI_(p: {
             tabIndex={-1}
             onMouseDown={(ev) => {
                 if (ev.button == 0) {
-                    p.onValueChange(!isActive)
-                    ev.stopPropagation()
-
                     wasEnabled = !isActive
                     isDragging = true
+
+                    ev.stopPropagation()
                     window.addEventListener('mouseup', isDraggingListener, true)
+
+                    if (!p.onValueChange) {
+                        return
+                    }
+                    p.onValueChange(!isActive)
                 }
             }}
             onMouseEnter={(ev) => {
                 if (isDragging) {
+                    if (!p.onValueChange) {
+                        return
+                    }
+
                     p.onValueChange(wasEnabled)
                 }
             }}

--- a/src/controls/widgets/bool/WidgetBool.tsx
+++ b/src/controls/widgets/bool/WidgetBool.tsx
@@ -8,10 +8,43 @@ import { hash } from 'ohash'
 import { WidgetDI } from '../WidgetUI.DI'
 import { WidgetBoolUI } from './WidgetBoolUI'
 
-// CONFIG
+/**
+ * Bool Config
+ * @property {string} label2 - test
+ */
 export type Widget_bool_config = WidgetConfigFields<{
     default?: boolean
+
     label2?: string
+
+    /** Text to display, drawn by the widget itself. */
+    text?: string
+
+    /**
+     * The display style of the widget.
+     * - `check `: Shows a simple checkbox.
+     * - `button`: Shows a toggle-able button.
+     *
+     *  Defaults to 'check'
+     */
+    display?: 'check' | 'button'
+
+    /** Whether or not to expand the widget to take up as much space as possible
+     *
+     *      If `display` is 'check'
+     *          undefined and true will expand
+     *          false will disable expansion
+     *
+     *      If `display` is 'button'
+     *          undefined and false will not expand
+     *          true will enable expansion
+     */
+    expand?: boolean
+
+    /** Set the icon of the button
+     *  - Uses "material-symbols-outlined" as the icon set
+     */
+    icon?: string | undefined
 }>
 
 // SERIAL

--- a/src/controls/widgets/bool/WidgetBoolUI.tsx
+++ b/src/controls/widgets/bool/WidgetBoolUI.tsx
@@ -2,29 +2,27 @@ import type { Widget_bool } from './WidgetBool'
 
 import { runInAction } from 'mobx'
 import { observer } from 'mobx-react-lite'
+import { InputBoolUI } from './InputBoolUI'
+
+let isDragging = false
+let wasEnabled = false
 
 export const WidgetBoolUI = observer(function WidgetBoolUI_(p: { widget: Widget_bool }) {
     const widget = p.widget
-    const isActive = widget.serial.active
-    const toggle = () => runInAction(widget.toggle)
-    const checkbox = (
-        <input
-            type='checkbox'
-            checked={isActive}
-            tw={['checkbox checkbox-primary']}
-            tabIndex={-1}
-            onClick={(ev) => {
-                ev.stopPropagation()
-                toggle()
-            }}
-        />
-    )
-    return widget.config.label2 == null ? (
-        checkbox
-    ) : (
-        <div tw='flex gap-2'>
-            {checkbox}
-            <div tw='text-primary'>{widget.config.label2}</div>
-        </div>
+    let label = widget.config.text ?? widget.config.label2
+
+    if (widget.config.label2) {
+        console.warn('label2 is deprecated, please use the text option instead. label2 will be removed in the future')
+    }
+
+    return (
+        <InputBoolUI //
+            active={widget.serial.active}
+            display={widget.config.display}
+            expand={widget.config.expand}
+            icon={widget.config.icon}
+            text={label}
+            onValueChange={(value) => (widget.serial.active = value)}
+        ></InputBoolUI>
     )
 })

--- a/src/controls/widgets/choices/WidgetChoicesUI.tsx
+++ b/src/controls/widgets/choices/WidgetChoicesUI.tsx
@@ -2,12 +2,11 @@ import type { Widget_choices } from './WidgetChoices'
 import type { SchemaDict } from 'src/cards/App'
 
 import { observer } from 'mobx-react-lite'
-import { useState } from 'react'
 
 import { WidgetWithLabelUI } from '../../shared/WidgetWithLabelUI'
 import { AnimatedSizeUI } from './AnimatedSizeUI'
 import { SelectUI } from 'src/rsuite/SelectUI'
-import { makeLabelFromFieldName } from 'src/utils/misc/makeLabelFromFieldName'
+import { InputBoolUI } from '../bool/InputBoolUI'
 
 // UI
 export const WidgetChoices_HeaderUI = observer(function WidgetChoices_LineUI_<T extends SchemaDict>(p: {
@@ -56,50 +55,22 @@ const WidgetChoices_TabHeaderUI = observer(function WidgetChoicesTab_LineUI_<T e
 }) {
     const widget = p.widget
     const choices = widget.choicesWithLabels // choicesStr.map((v) => ({ key: v }))
-    const [isDragging, setIsDragging] = useState<boolean>(false)
-    const [wasEnabled, setWasEnabled] = useState<boolean>(false)
-
-    const isDraggingListener = (ev: MouseEvent) => {
-        if (ev.button == 0) {
-            setIsDragging(false)
-            window.removeEventListener('mouseup', isDraggingListener, true)
-        }
-    }
 
     return (
         <div tw='rounded select-none ml-auto justify-end flex flex-wrap gap-x-0.5 gap-y-0'>
             {choices.map((c) => {
                 const isSelected = widget.serial.branches[c.key]
                 return (
-                    <div
-                        onMouseDown={(ev) => {
-                            // console.log('DOWN!!')
-                            if (ev.button == 0) {
-                                widget.toggleBranch(c.key)
-                                setWasEnabled(!isSelected)
-                                setIsDragging(true)
-                                window.addEventListener('mouseup', isDraggingListener, true)
-                            }
-                        }}
-                        onMouseEnter={(ev) => {
-                            if (isDragging && (wasEnabled != isSelected || !widget.isMulti)) {
+                    <InputBoolUI
+                        active={isSelected}
+                        display='button'
+                        text={c.label}
+                        onValueChange={(value) => {
+                            if (value != isSelected) {
                                 widget.toggleBranch(c.key)
                             }
                         }}
-                        key={c.key}
-                        tw={[
-                            //
-                            'cursor-pointer',
-                            'rounded',
-                            'border px-2 flex flex-nowrap gap-0.5 whitespace-nowrap items-center bg-base-100',
-                            isSelected
-                                ? 'bg-primary text-base-300 border-base-200 text-shadow-inv'
-                                : 'bg-base-200 hover:filter hover:brightness-110 border-base-100 text-shadow',
-                            'border-b-2 border-b-base-300',
-                        ]}
-                    >
-                        {makeLabelFromFieldName(c.label)}
-                    </div>
+                    ></InputBoolUI>
                 )
             })}
         </div>

--- a/src/controls/widgets/optional/WidgetOptional.tsx
+++ b/src/controls/widgets/optional/WidgetOptional.tsx
@@ -64,8 +64,7 @@ export class Widget_optional<T extends Spec = Spec> implements IWidget<Widget_op
      * */
     // ⏸️ INIT_MODE: 'LAZY' | 'EAGER' = 'EAGER'
 
-    toggleAndUpdateChildCollapsedState = () => {
-        this.toggle()
+    UpdateChildCollapsedState = () => {
         if (this.child) {
             if (this.serial.active) this.child.serial.collapsed = false
             else this.child.serial.collapsed = true

--- a/src/rsuite/reveal/RevealUI.tsx
+++ b/src/rsuite/reveal/RevealUI.tsx
@@ -74,6 +74,12 @@ export const RevealUI = observer(function Tooltip_(p: RevealProps) {
                   <div
                       className={p.tooltipWrapperClassName}
                       tw={['_RevealUI card card-bordered bg-base-100 shadow-xl pointer-events-auto']}
+                      onMouseDown={(ev) => {
+                          p.onClick?.(ev)
+                          uist.close()
+                          ev.stopPropagation()
+                          ev.preventDefault()
+                      }}
                       onClick={(ev) => {
                           ev.stopPropagation()
                           ev.preventDefault()
@@ -120,6 +126,10 @@ export const RevealUI = observer(function Tooltip_(p: RevealProps) {
             onContextMenu={uist.toggleLock}
             onMouseEnter={uist.onMouseEnterAnchor}
             onMouseLeave={uist.onMouseLeaveAnchor}
+            onMouseDown={(ev) => {
+                ev.stopPropagation()
+                ev.preventDefault()
+            }}
             onClick={
                 uist.triggerOnClick
                     ? (ev) => {

--- a/src/theme/theme.css
+++ b/src/theme/theme.css
@@ -45,6 +45,11 @@ body {
     /* border-bottom: 1px solid oklch(var(--p)/.4); */
     padding: 2px;
 }
+
+.WIDGET-GROUP-BORDERED:hover .WIDGET-COLLAPSE-BTN {
+    opacity: 100% !important;
+}
+
 .SUB-FIELD {
     flex: 1;
     /* background: #272729; */


### PR DESCRIPTION
#### Misc. Changes
- Moves logic to \<InputBoolUI\> so that it's easily re-usable as a checkbox for other widgets
- Adds a deprecation warning for label2 on Widget_BoolUI, it should be replaced with the new text option
- Dragging to make checkbox share a similar state when you drag over them should work with more areas now that more things will use the same underlying widget instead of duplicated code. (Only WidgetBoolUI, Widget_ToggleUI, and SelectUI (search enum, choices) with this PR)

#### InputBoolUI
- `expand` Makes the widget use as much space as possible (horizontally)
- `icon` Uses a material-symbols-outlined icon name (Not sure how to type this correctly so it's just a string, but displaying all the icon names would be cool)
- `display` Sets the way the widget is displayed
- - `check` gives you a normal checkbox, with the text/icon to the right
- - `button` gives you a toggle-able button similar to how form.choices() looks.
- Thing to note is that the display function changes how the undefined state of expand is interpreted, with 'check' using an expand = true by default, and 'button' using an expand = false by default.

#### WidgetChoicesUI
- Use InputBoolUI

#### SelectUI
- Use InputBoolUI
- Clicking on any non-button part of the pop-up no longer closes it.
- Un-focuses the underlying text input when the menu closes.
*Fixes the pop-up opening when you un-focus and re-focus the window when the pop-up is active, also just feels nicer. Probably really only hurt the experience for people who use focus window under mouse, like me. uvu*
- Closes the pop-up when you are a certain distance away from one of the edges.
*Gives people a bit of slack with moving their mouse to/in the pop-up*
- You can now drag to set multiple entries to the same state instead of having to click each one individually.
- Fake the gaps between entries.
*Follows Fitt's law by having no dead areas between the part of the buttons the user can click.*

#### WidgetWithLabelUI
- Make the header collapse/expand panels, buttons should preventDefault/stopPropagation in onMouseDown to prevent themselves from triggering this if they're in the header.
- Holding left mouse and dragging over the headers of panels now quickly expands/collapses them.

