### PR TITLE
Fix import importing twice

### DIFF
--- a/src/panels/Panel_Import.tsx
+++ b/src/panels/Panel_Import.tsx
@@ -26,9 +26,9 @@ export const Panel_Import = observer(function Panel_Import_(p: {}) {
                     </div>
                 ))}
             </div>
-            <div tw='relative w-96 h-96 virtualBorder'>
+            {/* <div tw='relative w-96 h-96 virtualBorder'>
                 <TargetBox />
-            </div>
+            </div> */}
         </div>
     )
 })

--- a/src/widgets/misc/MainUI.tsx
+++ b/src/widgets/misc/MainUI.tsx
@@ -22,9 +22,10 @@ export const MainUI = observer(() => {
         <stContext.Provider value={st}>
             <ToastContainer />
             <DndProvider backend={HTML5Backend}>
-                <TargetBox>
-                    <CushyUI />
-                </TargetBox>
+                {/* Do not import twice */}
+                {/* <TargetBox> */}
+                <CushyUI />
+                {/* </TargetBox> */}
             </DndProvider>
         </stContext.Provider>
     )


### PR DESCRIPTION
Also removes the \<TargetBox\> from the Import dock.
TargetBox is completely un-used now.