### PR TITLE
Use the realtimeResize option for <Layout>

### DIFF
--- a/src/panels/router/Layout.tsx
+++ b/src/panels/router/Layout.tsx
@@ -120,6 +120,9 @@ export class CushyLayoutManager {
                         }
                     }
                 }}
+                /* This is more responsive and better for stuff like the gallery, where you may want to match the size of the panel to the size of the images.
+                 * Click => Dragging => Unclick is very annoying when you want something a specific way and need to see the changes quickly. */
+                realtimeResize
                 onModelChange={(model) => {
                     runInAction(() => {
                         this.currentTabSet = model.getActiveTabset()


### PR DESCRIPTION
Way more responsive for the user.
Could maybe be optional for performance saving on lower-end devices?