### PR TITLE
Improve Plugin_LoraBoxUI's UX

### DIFF
--- a/src/controls/widgets/prompt/plugins/Plugin_LoraBoxUI.tsx
+++ b/src/controls/widgets/prompt/plugins/Plugin_LoraBoxUI.tsx
@@ -2,7 +2,7 @@ import { observer } from 'mobx-react-lite'
 
 import { openExternal } from 'src/app/layout/openExternal'
 import { InputNumberUI } from 'src/controls/widgets/number/InputNumberUI'
-import { Prompt_Lora } from 'src/controls/widgets/prompt/grammar/grammar.practical'
+import { Prompt_Lora, Prompt_WeightedExpression } from 'src/controls/widgets/prompt/grammar/grammar.practical'
 import { WidgetPromptUISt } from 'src/controls/widgets/prompt/WidgetPromptUISt'
 import { MessageErrorUI } from 'src/panels/MessageUI'
 import { Button, Input } from 'src/rsuite/shims'
@@ -17,14 +17,25 @@ export const Plugin_LoraControlsUI = observer(function Plugin_LoraControlsUI_(p:
         <>
             {uist.loras.length === 0 && <div tw='italic text-gray-500'>No loras in prompt</div>}
             <div tw='flex flex-col p-1 gap-1'>
-                {uist.loras.map((loraASTNode, ix) => (
-                    <LoraBoxUI //
-                        key={`${loraASTNode.name}-${ix}`}
-                        uist={uist}
-                        loraASTNode={loraASTNode}
-                        onDelete={() => loraASTNode.remove()}
-                    />
-                ))}
+                {uist.loras.map((loraASTNode, ix) => {
+                    const weighted = loraASTNode.firstAncestor('WeightedExpression')
+
+                    return (
+                        <LoraBoxUI //
+                            key={`${loraASTNode.name}-${ix}`}
+                            uist={uist}
+                            loraASTNode={loraASTNode}
+                            weightedASTNode={weighted}
+                            onDelete={() => {
+                                if (weighted) {
+                                    weighted.remove()
+                                } else {
+                                    loraASTNode.remove()
+                                }
+                            }}
+                        />
+                    )
+                })}
             </div>
         </>
     )
@@ -34,6 +45,7 @@ const LoraBoxUI = observer(function LoraBoxUI_(p: {
     //
     uist: WidgetPromptUISt
     loraASTNode: Prompt_Lora
+    weightedASTNode: Maybe<Prompt_WeightedExpression>
     onDelete: () => void
 }) {
     const node = p.loraASTNode
@@ -43,7 +55,7 @@ const LoraBoxUI = observer(function LoraBoxUI_(p: {
     const loraMetadata = st.configFile.value?.loraPrompts?.[loraName]
     const associatedText = loraMetadata?.text ?? ''
     const associatedUrl = loraMetadata?.url ?? ''
-    const weighted = p.loraASTNode.firstAncestor('WeightedExpression')
+    const weighted = p.weightedASTNode
 
     // const numbers = def.ref.node.getChildren('Number')
     return (


### PR DESCRIPTION
- It will now delete the surrounding weighted expression
*NOTE: Only if the lora is the only thing in the expression*
- This also cleans up trailing whitespace/commas
- Adjusting the weight will make a new WeightedExpression around the
lora instead of adjusting a parent's weights