### PR TITLE
Improve copying image to clipboard

### DIFF
--- a/src/shell/main.js
+++ b/src/shell/main.js
@@ -1,5 +1,6 @@
 const { mkdirSync } = require('fs')
 const { cwd } = require('process')
+const { clipboard } = require('electron')
 
 START()
 
@@ -108,6 +109,16 @@ async function START() {
     ipcMain.on('close-devtools', (event, arg) => {
         const focusedWindow = BrowserWindow.getFocusedWindow()
         if (focusedWindow) focusedWindow.webContents.closeDevTools()
+    })
+    ipcMain.on('copy-image-to-clipboard', (event, arg) => {
+        try {
+            // Always use 'image/png' for now as it seems like nothing supports anything but image/png
+            clipboard.writeBuffer('image/png', arg.buffer);
+            event.sender.send('image-copied', {result: true, data: arg.buffer})
+        } catch (err) {
+            console.error(err)
+            event.sender.send('image-copied', {result: false, data: err})
+        }
     })
 
     // required to interract with ComfyUI

--- a/src/utils/electron/ElectronUtils.ts
+++ b/src/utils/electron/ElectronUtils.ts
@@ -18,6 +18,11 @@ export type SearchResult_IPCPayload = {
     finalUpdate: boolean // true
 }
 
+export type Clipboard_ImagePayload = {
+    format?: string // 'png' | 'webp' | 'raw' | 'jpeg'
+    buffer: Buffer
+}
+
 export class ElectronUtils {
     constructor(public st: STATE) {
         const ipcRenderer = window.require('electron').ipcRenderer
@@ -63,5 +68,20 @@ export class ElectronUtils {
         } catch (error) {
             console.error('❌ failed to close DevTools', error)
         }
+    }
+
+    copyImageToClipboard = (payload: Clipboard_ImagePayload) => {
+        return new Promise((resolve, reject) => {
+            const format = payload.format ?? 'png'
+            const ipcRenderer = window.require('electron').ipcRenderer
+            ipcRenderer.once('image-copied', (event, response) => {
+                response.result === true ? resolve(response.data) : reject(response.data)
+            })
+
+            ipcRenderer.send('copy-image-to-clipboard', {
+                format,
+                buffer: payload.buffer,
+            })
+        })
     }
 }

--- a/src/utils/misc/toasts.ts
+++ b/src/utils/misc/toasts.ts
@@ -1,9 +1,0 @@
-import { useMemo } from 'react'
-import { toast, ToastPosition } from 'react-toastify'
-
-const position: ToastPosition = 'bottom-right'
-export const toastSuccess = (msg: string) => void toast(msg, { type: 'success', position })
-export const toastInfo = (msg: string) => void toast(msg, { type: 'info', position })
-export const toastError = (msg: string) => void toast(msg, { type: 'error', position })
-
-useMemo

--- a/src/utils/misc/toasts.tsx
+++ b/src/utils/misc/toasts.tsx
@@ -1,0 +1,28 @@
+import { toast, ToastPosition } from 'react-toastify'
+
+const position: ToastPosition = 'bottom-right'
+export const toastSuccess = (msg: string) => void toast(msg, { type: 'success', position })
+export const toastInfo = (msg: string) => void toast(msg, { type: 'info', position })
+export const toastError = (msg: string) => void toast(msg, { type: 'error', position })
+
+// Function to show toast with an image
+export const toastImage = (imageSrc: string | Buffer, message: string) => {
+    const src = typeof imageSrc === 'string' ? imageSrc : imageSrc.toString('base64')
+    console.log(src)
+    const CustomToast = () => (
+        <div tw='flex flex-col aspect-square'>
+            <img
+                tw='object-contain bg-black rounded'
+                src={`${src}`}
+                alt='Toast Image'
+                style={{ width: '256px', height: '256px' }}
+            />
+            <p>{message}</p>
+        </div>
+    )
+
+    toast(<CustomToast />, {
+        position: 'bottom-right',
+        pauseOnFocusLoss: false,
+    })
+}


### PR DESCRIPTION
- Use Electron's api to do the operation instead of the Browser's
- No longer needlessly converting buffers, so should be way faster
- Will always work, even if the window becomes un-focused
- New toast for displaying the copied image

This may be a bit sloppy.