### PR TITLE
Model Modifiers - Perturbed Attention and Kohya Deep Shrink

### DIFF
--- a/library/built-in/CushyDiffusion.ts
+++ b/library/built-in/CushyDiffusion.ts
@@ -8,7 +8,7 @@ import { run_refiners_fromImage, ui_refiners } from './_prefabs/prefab_detailer'
 import { run_latent_v3, ui_latent_v3 } from './_prefabs/prefab_latent_v3'
 import { output_demo_summary } from './_prefabs/prefab_markdown'
 import { ui_mask } from './_prefabs/prefab_mask'
-import { run_model, ui_model } from './_prefabs/prefab_model'
+import { run_model, run_model_modifiers, ui_model } from './_prefabs/prefab_model'
 import { run_prompt } from './_prefabs/prefab_prompt'
 import { run_advancedPrompt, ui_advancedPrompt } from './_prefabs/prefab_promptsWithButtons'
 import { ui_recursive } from './_prefabs/prefab_recursive'
@@ -158,7 +158,7 @@ app({
 
         // FIRST PASS --------------------------------------------------------------------------------
         const ctx_sampler: Ctx_sampler = {
-            ckpt: ckptPos,
+            ckpt: run_model_modifiers(ui.model, ckptPos, false),
             clip: clipPos,
             vae,
             latent,
@@ -197,7 +197,7 @@ app({
         const HRF = ui.highResFix
         if (HRF) {
             const ctx_sampler_fix: Ctx_sampler = {
-                ckpt: ckptPos,
+                ckpt: run_model_modifiers(ui.model, ckptPos, true, ui.highResFix.scaleFactor),
                 clip: clipPos,
                 vae,
                 latent,
@@ -230,8 +230,8 @@ app({
                     cfg: ui.sampler.cfg,
                     steps: HRF.steps,
                     denoise: HRF.denoise,
-                    sampler_name: 'ddim',
-                    scheduler: 'ddim_uniform',
+                    sampler_name: ui.highResFix.useMainSampler ? ui.sampler.sampler_name : 'ddim',
+                    scheduler: ui.highResFix.useMainSampler ? ui.sampler.scheduler : 'ddim_uniform',
                 },
                 { ...ctx_sampler_fix, latent, preview: false },
             ).latent

--- a/library/built-in/_prefabs/prefab_model.ts
+++ b/library/built-in/_prefabs/prefab_model.ts
@@ -12,7 +12,10 @@ export const ui_model = () => {
             if (ui.extra.freeUv2) out += ' + FreeUv2'
             if (ui.extra.vae) out += ' + VAE'
             if (ui.extra.clipSkip) out += ` + ClipSkip(${ui.extra.clipSkip})`
+            if (ui.extra.pag) out += ` + PAG(${ui.extra.pag.scale})`
             if (ui.extra.sag) out += ` + SAG(${ui.extra.sag.scale}/${ui.extra.sag.blur_sigma})`
+            if (ui.extra.KohyaDeepShrink) out += ` + Shrink(${ui.extra.KohyaDeepShrink})`
+
             return out
         },
         items: {
@@ -30,14 +33,92 @@ export const ui_model = () => {
                     clipSkip: form.int({ label: 'Clip Skip', default: 1, min: 1, max: 5 }),
                     freeU: form.group(),
                     freeUv2: form.group(),
-                    sag: form.group({
-                        startCollapsed: true,
-                        tooltip: 'Self Attention Guidance can improve image quality but runs slower',
-                        items: {
+                    pag: form.fields(
+                        {
+                            include: form.choices({
+                                items: { base: form.fields({}), hiRes: form.fields({}) },
+                                appearance: 'tab',
+
+                                default: { base: true, hiRes: false },
+                            }),
+                            scale: form.float({
+                                default: 3,
+                                min: 0,
+                                softMax: 6,
+                                max: 100,
+                                step: 0.1,
+                                tooltip:
+                                    'PAG scale, has some resemblance to CFG scale - higher values can both increase structural coherence of the image and oversaturate/fry it entirely. Note: Default for standard models is 3, but that fries lightning and turbo models, so lower it accordingly. Try 0.9 ish for turbo.',
+                            }),
+                            adaptiveScale: form.float({
+                                default: 0,
+                                min: 0,
+                                max: 1,
+                                step: 0.1,
+                                tooltip:
+                                    'PAG dampening factor, it penalizes PAG during late denoising stages, resulting in overall speedup: 0.0 means no penalty and 1.0 completely removes PAG.',
+                            }),
+                        },
+                        {
+                            startCollapsed: true,
+                            tooltip: 'Perturbed Attention Guidance - can improve attention at the cost of performance',
+                            summary: (ui) => {
+                                return `scale:${ui.scale}`
+                            },
+                        },
+                    ),
+                    sag: form.fields(
+                        {
+                            include: form.choices({
+                                items: { base: form.fields({}), hiRes: form.fields({}) },
+                                appearance: 'tab',
+                                default: { base: true, hiRes: true },
+                            }),
                             scale: form.float({ default: 0.5, step: 0.1, min: -2.0, max: 5.0 }),
                             blur_sigma: form.float({ default: 2.0, step: 0.1, min: 0, max: 10.0 }),
                         },
-                    }),
+                        { startCollapsed: true, tooltip: 'Self Attention Guidance can improve image quality but runs slower' },
+                    ),
+                    KohyaDeepShrink: form.fields(
+                        {
+                            include: form.choices({
+                                items: { base: form.fields({}), hiRes: form.fields({}) },
+                                appearance: 'tab',
+                                default: { base: false, hiRes: true },
+                            }),
+                            advancedSettings: form.fields(
+                                {
+                                    downscaleFactor: form.float({
+                                        default: 2,
+                                        min: 0.1,
+                                        max: 9,
+                                        softMax: 4,
+                                        step: 0.25,
+                                        tooltip: 'only applies to shrink on base model. hires will use hires scale factor.',
+                                    }),
+                                    block_number: form.int({ default: 3, max: 32, min: 1 }),
+                                    startPercent: form.float({ default: 0, min: 0, max: 1, step: 0.05 }),
+                                    endPercent: form.float({ default: 0.35, min: 0, max: 1, step: 0.05 }),
+                                    downscaleAfterSkip: form.bool({ default: false }),
+                                    downscaleMethod: form.enum.Enum_PatchModelAddDownscale_downscale_method({
+                                        default: 'bislerp',
+                                    }),
+                                    upscaleMethod: form.enum.Enum_PatchModelAddDownscale_upscale_method({ default: 'bislerp' }),
+                                },
+                                { startCollapsed: true },
+                            ),
+                        },
+                        {
+                            startCollapsed: true,
+                            tooltip:
+                                'Shrinks and patches the model. Can be used to generate resolutions higher than the model training and helps with hires fix.',
+                            summary: (ui) => {
+                                return `${ui.include.base ? '🟢Base ' : ''}${ui.include.hiRes ? '🟢HiRes ' : ''}(${
+                                    ui.advancedSettings.downscaleFactor
+                                })`
+                            },
+                        },
+                    ),
                     civitai_ckpt_air: form
                         .string({
                             tooltip: 'Civitai checkpoint Air, as found on the civitai Website. It should look like this: 43331@176425', // prettier-ignore
@@ -93,15 +174,47 @@ export const run_model = (
     if (ui.extra.freeUv2) ckpt = graph.FreeU$_V2({ model: ckpt })
     else if (ui.extra.freeU) ckpt = graph.FreeU({ model: ckpt })
 
-    // 5. Optional SAG - Self Attention Guidance
-    if (ui.extra.sag) {
-        ckpt = graph.SelfAttentionGuidance({ scale: ui.extra.sag.scale, blur_sigma: ui.extra.sag.blur_sigma, model: ckpt })
-    }
-
     /* Rescale CFG */
     if (ui.extra.rescaleCFG) {
         ckpt = graph.RescaleCFG({ model: ckpt, multiplier: ui.extra.rescaleCFG })
     }
 
     return { ckpt, vae, clip }
+}
+
+export const run_model_modifiers = (
+    ui: OutputFor<typeof ui_model>,
+    ckpt: _MODEL,
+    forHiRes?: boolean,
+    kohyaScale?: number,
+): _MODEL => {
+    const run = getCurrentRun()
+    const graph = run.nodes
+    // 5. Optional SAG - Self Attention Guidance
+    if (ui.extra.sag && ((!forHiRes && ui.extra.sag.include.base) || (forHiRes && ui.extra.sag.include.hiRes))) {
+        ckpt = graph.SelfAttentionGuidance({ scale: ui.extra.sag.scale, blur_sigma: ui.extra.sag.blur_sigma, model: ckpt })
+    }
+    // 6. Optional PAG - Perturbed Attention Guidance
+    if (ui.extra.pag && ((!forHiRes && ui.extra.pag.include.base) || (forHiRes && ui.extra.pag.include.hiRes))) {
+        ckpt = graph.PerturbedAttention({ scale: ui.extra.pag.scale, model: ckpt, adaptive_scale: ui.extra.pag.adaptiveScale })
+    }
+    // 7. Kohya Deepshrink
+    if (
+        ui.extra.KohyaDeepShrink &&
+        ((!forHiRes && ui.extra.KohyaDeepShrink.include.base) || (forHiRes && ui.extra.KohyaDeepShrink.include.hiRes))
+    ) {
+        const setScale = forHiRes ? kohyaScale : ui.extra.KohyaDeepShrink.advancedSettings.downscaleFactor ?? 2
+        const set = ui.extra.KohyaDeepShrink.advancedSettings
+        ckpt = graph.PatchModelAddDownscale({
+            downscale_factor: setScale,
+            model: ckpt,
+            block_number: set.block_number,
+            start_percent: set.startPercent,
+            end_percent: set.endPercent,
+            downscale_after_skip: set.downscaleAfterSkip,
+            downscale_method: set.downscaleMethod,
+            upscale_method: set.upscaleMethod,
+        })
+    }
+    return ckpt
 }


### PR DESCRIPTION
1. Added perturbed attention guidance
Can improve attention at the cost of performance.
Support for both base pass and hires pass
(there is a breaking change for any existing app using run_model that SAG won't be included anymore, refer to CushyDiffusion for new method)
2. Added Kohya Deep Shrink
Can adapt models to higher resolution than training, and helps with coherence for non-tiled hires fix. Example use: SD1.5 generate 2048x2048 using kohya scale of 4. Or upscale 512x512 4x on hires fix with less artifacts.
3. Added selection to SAG to choose if it applies to base or hires pass