### PR TITLE
eye detailer improvements, prompt list prefab, and video tweaks

### DIFF
--- a/library/built-in/_prefabs/prefab_detailer.ts
+++ b/library/built-in/_prefabs/prefab_detailer.ts
@@ -100,8 +100,8 @@ export const ui_refiners = () => {
         },
         {
             summary: (ui) => {
-                return `${ui.refinerType.faces ? 'FACE' : ''} ${ui.refinerType.hands ? 'HANDS' : ''} ${
-                    ui.refinerType.hands ? 'EYES' : ''
+                return `Refiners ${ui.refinerType.faces ? 'FACE' : ''} ${ui.refinerType.hands ? 'HANDS' : ''} ${
+                    ui.refinerType.eyes ? 'EYES' : ''
                 }`
             },
         },
@@ -123,6 +123,10 @@ export const run_refiners_fromImage = (
     //
     ui: OutputFor<typeof ui_refiners>,
     finalImage: _IMAGE = getCurrentRun().AUTO,
+    ckpt?: _MODEL,
+    maxRes?: number,
+    face_prompt_override?: Maybe<string>,
+    eye_prompt_override?: Maybe<string>,
 ): _IMAGE => {
     const run = getCurrentRun()
     const graph = run.nodes
@@ -143,7 +147,7 @@ export const run_refiners_fromImage = (
                 bbox_detector: provider._BBOX_DETECTOR,
                 sam_model_opt: samLoader?._SAM_MODEL,
                 seed: ui.settings.sampler?.seed ?? run.randomSeed(),
-                model: run.AUTO,
+                model: ckpt ?? run.AUTO,
                 clip: run.AUTO,
                 vae: run.AUTO,
                 denoise: ui.settings.sampler.denoise,
@@ -151,7 +155,7 @@ export const run_refiners_fromImage = (
                 sampler_name: ui.settings.sampler.sampler_name,
                 scheduler: ui.settings.sampler.scheduler,
                 cfg: ui.settings.sampler.cfg,
-                positive: graph.CLIPTextEncode({ clip: run.AUTO, text: facePrompt }),
+                positive: graph.CLIPTextEncode({ clip: run.AUTO, text: face_prompt_override ?? facePrompt }),
                 negative: graph.CLIPTextEncode({ clip: run.AUTO, text: faceNegativeDefault }),
                 sam_detection_hint: 'center-1', // ❓
                 sam_mask_hint_use_negative: 'False',
@@ -223,7 +227,7 @@ export const run_refiners_fromImage = (
                 scheduler: ui.settings.sampler.scheduler,
                 cfg: ui.settings.sampler.cfg,
                 guide_size: 128,
-                positive: graph.CLIPTextEncode({ clip: run.AUTO, text: eyesPrompt }),
+                positive: graph.CLIPTextEncode({ clip: run.AUTO, text: eye_prompt_override ?? eyesPrompt }),
                 negative: graph.CLIPTextEncode({ clip: run.AUTO, text: 'bad eyes, bad anatomy, bad details' }),
                 wildcard: '',
             })

--- a/library/built-in/_prefabs/prefab_prompt_list.ts
+++ b/library/built-in/_prefabs/prefab_prompt_list.ts
@@ -1,0 +1,99 @@
+import type { OutputFor } from './_prefabs'
+
+import { run_prompt } from './prefab_prompt'
+
+export const ui_promptList = () => {
+    const form = getCurrentForm()
+    return form.fields(
+        {
+            joinType: form.choice({
+                items: {
+                    concat: form.fields({}),
+                    combine: form.fields({}),
+                    average: form.fields({ strength: form.float({ default: 1 }) }),
+                },
+                appearance: 'tab',
+                startCollapsed: true,
+            }),
+            promptList: form.list({
+                element: form.fields(
+                    {
+                        prompt: form.prompt(),
+                        mask: form.image({}),
+                        invert: form.bool({}),
+                        mode: form.enum.Enum_LoadImageMask_channel({}),
+                        blur: form.float({ default: 6, min: 0, max: 2048, softMax: 24, step: 1 }),
+                    },
+                    {
+                        summary: (ui) => {
+                            return `${ui.prompt}`
+                        },
+                    },
+                ),
+            }),
+        },
+        {
+            summary: (ui) => {
+                return `(${ui.promptList.length})${ui.joinType}`
+            },
+        },
+    )
+}
+
+export const run_promptList = async (p: {
+    opts: OutputFor<typeof ui_promptList>
+    conditioning: _CONDITIONING
+    width?: number
+    height?: number
+    encoderTypeSDXL?: boolean
+    promptPreface?: string
+    promptSuffix?: string
+}) => {
+    const run = getCurrentRun()
+    const graph = run.nodes
+    let newConditioning = p.conditioning
+
+    for (const item of p.opts.promptList) {
+        const promptReturn = run_prompt({
+            prompt: item.prompt,
+            clip: run.AUTO,
+            ckpt: run.AUTO,
+            printWildcards: true,
+        })
+        const promptText = p.promptPreface + promptReturn.promptIncludingBreaks + p.promptSuffix
+        const promptEncode = p.encoderTypeSDXL
+            ? run.nodes.CLIPTextEncodeSDXL({
+                  clip: run.AUTO,
+                  text_g: promptText,
+                  text_l: promptText,
+                  width: p.width ?? 1024,
+                  height: p.height ?? 1024,
+                  target_height: p.width ?? 1024,
+                  target_width: p.height ?? 1024,
+              })
+            : graph.CLIPTextEncode({
+                  clip: run.AUTO,
+                  text: promptText,
+              })
+
+        if (p.opts.joinType.average) {
+            newConditioning = run.nodes.ConditioningAverage({
+                conditioning_from: newConditioning,
+                conditioning_to: promptEncode._CONDITIONING,
+                conditioning_to_strength: p.opts.joinType.average?.strength,
+            })
+        } else if (p.opts.joinType.combine) {
+            newConditioning = run.nodes.ConditioningCombine({
+                conditioning_1: promptEncode._CONDITIONING,
+                conditioning_2: newConditioning,
+            })
+        } else {
+            newConditioning = run.nodes.ConditioningConcat({
+                conditioning_from: newConditioning,
+                conditioning_to: promptEncode._CONDITIONING,
+            })
+        }
+    }
+
+    return { conditioning: newConditioning }
+}

--- a/library/built-in/_prefabs/prefab_sampler.ts
+++ b/library/built-in/_prefabs/prefab_sampler.ts
@@ -9,13 +9,11 @@ export const ui_sampler = (p?: {
     cfg?: number
     sampler_name?: Enum_KSampler_sampler_name
     scheduler?: Enum_KSampler_scheduler
+    startCollapsed?: boolean
 }) => {
     const form: FormBuilder = getCurrentForm()
-    return form.group({
-        summary: (ui) => {
-            return `denoise:${ui.denoise} steps:${ui.steps} cfg:${ui.cfg} sampler:${ui.sampler_name}/${ui.scheduler}`
-        },
-        items: {
+    return form.fields(
+        {
             denoise: form.float({ step: 0.1, min: 0, max: 1, default: p?.denoise ?? 1, label: 'Denoise' }),
             steps: form.int({ step: 10, default: p?.steps ?? 20, label: 'Steps', min: 0, softMax: 100 }),
             cfg: form.float({ step: 1, label: 'CFG', min: 0, max: 100, softMax: 10, default: p?.cfg ?? 7 }),
@@ -23,7 +21,13 @@ export const ui_sampler = (p?: {
             sampler_name: form.enum.Enum_KSampler_sampler_name({ label: 'Sampler', default: p?.sampler_name ?? 'euler' }),
             scheduler: form.enum.Enum_KSampler_scheduler({ label: 'Scheduler', default: p?.scheduler ?? 'karras' }),
         },
-    })
+        {
+            summary: (ui) => {
+                return `denoise:${ui.denoise} steps:${ui.steps} cfg:${ui.cfg} sampler:${ui.sampler_name}/${ui.scheduler}`
+            },
+            startCollapsed: p?.startCollapsed ?? false,
+        },
+    )
 }
 
 // CTX -----------------------------------------------------------

--- a/src/core/litegraphToPrompt.ts
+++ b/src/core/litegraphToPrompt.ts
@@ -129,8 +129,12 @@ export const convertLiteGraphToPrompt = (
                 if (isPrimitive) continue
 
                 // not a primitive => we assume it's a link
-                if (ipt.link == null) throw new Error(`no link found for ${node.id}.${ipt.name}`)
-
+                if (ipt.link == null) {
+                    console.log(
+                        `[❌] WARNING: no parent found for ${node.type}.${ipt.name} this could be an error if the input is not optional`,
+                    ) //throw new Error(`no link found for ${node.id}.${ipt.name}`)
+                    continue
+                }
                 // retrieve the parent
                 let parent: Maybe<ParentInfo> = getParentNode(ipt.link)
 

--- a/src/runtime/RuntimeVideo.ts
+++ b/src/runtime/RuntimeVideo.ts
@@ -64,7 +64,12 @@ export class RuntimeVideos {
         // 4. create video
         console.info(`🎥 this.folder.path: ${this.folder}`)
         console.info(`🎥 cwd: ${cwd}`)
-        const allAbsPaths = images.map((i) => i.absPath).filter((p) => p != null) as AbsolutePath[]
+        const allAbsPaths = images
+            .map((i) => i.absPath)
+            .filter((p) => p != null)
+            .sort()
+            .map((p) => p as AbsolutePath)
+
         const ffmpegComandInfos = await createMP4FromImages(allAbsPaths, targetVideoAbsPath, inputFPS, cwd, opts)
         if (ffmpegComandInfos) {
             this.st.db.media_text.create({


### PR DESCRIPTION
Found a better workflow for eye detailing
Added a prompt_list prefab, but don't have time to split off a separate example of use, sorry
Litegraph change was because import was erroring out on workflows that had optional inputs. Could be a one-off, so reject that one if you want.
RuntimeVideo was an issue with the images coming out slightly out of order