### PR TITLE
Wayland: Make .desktop file entries

### DIFF
--- a/_mac-linux-cleanup.sh
+++ b/_mac-linux-cleanup.sh
@@ -1,3 +1,12 @@
 set -eu
 rm -rf node_modules
 rm -rf .cushy
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+# Clean up .desktop entry and icon on linux
+if [ "$OS" = "linux" ]; then
+    rm "$HOME/.local/share/icons/cushystudio-shell.png" & # Run in bg because it's the easiest way to let it fail lmao
+    rm "$HOME/.local/share/applications/cushystudio-shell.desktop" &
+    echo "Removed icon and .desktop files"
+fi

--- a/_mac-linux-install.sh
+++ b/_mac-linux-install.sh
@@ -29,6 +29,37 @@ case "$OS" in
             "aarch64") NODE_ARCH="linux-arm64" ;; # aarch64 is another name for arm64 in Linux
             *) echo "Unsupported architecture: $ARCH for Linux"; exit 1 ;;
         esac
+
+        LSHARE="$HOME/.local/share"
+        SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+        mkdir -p $LSHARE/applications
+
+        echo "Installing icon to $LSHARE/icons/cushystudio-shell.png"
+        # Install icons and .desktop file for Wayland's title icon and tray name to work properly.
+        cp "./public/CushyLogo-512.png" "$LSHARE/icons/cushystudio-shell.png"
+
+        echo "Installing .desktop file to $LSHARE/applications/cushystudio-shell.desktop"
+        # The desktop file's name must match the app_id set by electron, which just seems to use the name set in the electron package.json
+        # https://github.com/electron/electron/issues/33578
+        # The cd feels hacky but it's needed unless we add that to the script itself.
+        # I know this is ugly, but do not format this to look nice or it will break.
+        echo "[Desktop Entry]
+Type=Application
+Name=CushyStudio
+Exec=/usr/bin/bash -c 'cd \"$SCRIPTPATH\" && \"$SCRIPTPATH/_mac-linux-start.sh\"'
+Path="$SCRIPTPATH"
+Icon=cushystudio-shell
+Terminal=false
+Actions=Developer;
+Keywords=Ai;Image Generation;
+
+[Desktop Action Developer]
+Name=CushyStudio (dev)
+Exec=/usr/bin/bash -c 'cd \"$SCRIPTPATH\" && \"$SCRIPTPATH/_mac-linux-start-dev.sh\"'
+" > "$LSHARE/applications/cushystudio-shell.desktop"
+
+        
         ;;
     *)
         echo "Unsupported operating system: $OS"; exit 1 ;;


### PR DESCRIPTION
- Fixes the icon not being used on Wayland, as there are no protocols to allow them to set this programmatically.
- Adds 2 entries to launch from launchers that look for .desktop files.
- One that launches Cushy normally, and one that starts the dev script.
- Not heavily tested on Wayland sessions other than KDE.