### PR TITLE
SD3, Flux, advanced sampling, and gallery quick-delete and star filter

### DIFF
--- a/library/built-in/CushyDiffusion.ts
+++ b/library/built-in/CushyDiffusion.ts
@@ -59,6 +59,18 @@ app({
             text: negPrompt.promptIncludingBreaks /* + posPrompt.negativeText */,
         })
 
+        //sd3 special negative conditioning
+        if (ui.model.ckpt_name.includes('sd3')) {
+            negative = graph.ConditioningCombine({
+                conditioning_1: graph.ConditioningSetTimestepRange({
+                    conditioning: graph.ConditioningZeroOut({ conditioning: negative }),
+                    start: 0.1,
+                    end: 1.0,
+                }),
+                conditioning_2: graph.ConditioningSetTimestepRange({ conditioning: negative, start: 0, end: 0.1 }),
+            })
+        }
+
         // const y = run_prompt({ richPrompt: negPrompt, clip, ckpt, outputWildcardsPicked: true })
         // let negative = y.conditionning
 

--- a/library/built-in/CushyDiffusion.ts
+++ b/library/built-in/CushyDiffusion.ts
@@ -11,7 +11,8 @@ import { run_prompt } from './_prefabs/prefab_prompt'
 import { run_advancedPrompt } from './_prefabs/prefab_promptsWithButtons'
 import { run_regionalPrompting_v1 } from './_prefabs/prefab_regionalPrompting_v1'
 import { run_rembg_v1 } from './_prefabs/prefab_rembg'
-import { Ctx_sampler, run_sampler } from './_prefabs/prefab_sampler'
+import { type Ctx_sampler, run_sampler } from './_prefabs/prefab_sampler'
+import { type Ctx_sampler_advanced, encodeText, run_sampler_advanced } from './_prefabs/prefab_sampler_advanced'
 import { run_upscaleWithModel } from './_prefabs/prefab_upscaleWithModel'
 import { run_addFancyWatermarkToAllImage, run_watermark_v1 } from './_prefabs/prefab_watermark'
 import { run_customSave } from './_prefabs/saveSmall'
@@ -58,19 +59,6 @@ app({
             clip,
             text: negPrompt.promptIncludingBreaks /* + posPrompt.negativeText */,
         })
-
-        //sd3 special negative conditioning
-        if (ui.model.ckpt_name.includes('sd3')) {
-            negative = graph.ConditioningCombine({
-                conditioning_1: graph.ConditioningSetTimestepRange({
-                    conditioning: graph.ConditioningZeroOut({ conditioning: negative }),
-                    start: 0.1,
-                    end: 1.0,
-                }),
-                conditioning_2: graph.ConditioningSetTimestepRange({ conditioning: negative, start: 0, end: 0.1 }),
-            })
-        }
-
         // const y = run_prompt({ richPrompt: negPrompt, clip, ckpt, outputWildcardsPicked: true })
         // let negative = y.conditionning
 
@@ -112,7 +100,7 @@ app({
         }
 
         // FIRST PASS --------------------------------------------------------------------------------
-        const ctx_sampler: Ctx_sampler = {
+        const ctx_sampler_advanced: Ctx_sampler_advanced = {
             ckpt: run_model_modifiers(ui.model, ckptPos, false),
             clip: clipPos,
             vae,
@@ -121,25 +109,33 @@ app({
             positive: positive,
             negative: negative,
             preview: false,
+            width: width,
+            height: height,
+            cfg: ui.sampler?.textEncoderType.FLUX ? ui.sampler.guidanceType?.CFG : undefined,
         }
-        latent = run_sampler(run, ui.sampler, ctx_sampler).latent
+        latent = run_sampler_advanced(run, ui.sampler, ctx_sampler_advanced).output
 
         // RECURSIVE PASS ----------------------------------------------------------------------------
         const extra = ui.extra
         if (extra.recursiveImgToImg) {
             for (let i = 0; i < extra.recursiveImgToImg.loops; i++) {
-                latent = run_sampler(
+                latent = run_sampler_advanced(
                     run,
                     {
                         seed: ui.sampler.seed + i,
-                        cfg: extra.recursiveImgToImg.cfg,
-                        steps: extra.recursiveImgToImg.steps,
-                        denoise: extra.recursiveImgToImg.denoise,
+                        guidanceType: { CFG: extra.recursiveImgToImg.cfg },
+                        sigmasType: {
+                            basic: {
+                                steps: extra.recursiveImgToImg.steps,
+                                denoise: extra.recursiveImgToImg.denoise,
+                                scheduler: 'ddim_uniform',
+                            },
+                        },
                         sampler_name: 'ddim',
-                        scheduler: 'ddim_uniform',
+                        textEncoderType: ui.sampler.textEncoderType,
                     },
-                    { ...ctx_sampler, latent, preview: true },
-                ).latent
+                    { ...ctx_sampler_advanced, latent, preview: true },
+                ).output
             }
         }
 
@@ -183,11 +179,15 @@ app({
                 run,
                 {
                     seed: ui.sampler.seed,
-                    cfg: ui.sampler.cfg,
+                    cfg:
+                        ui.sampler.guidanceType.CFG ??
+                        ui.sampler.guidanceType.DualCFG?.cfg ??
+                        ui.sampler.guidanceType.PerpNeg?.cfg ??
+                        6,
                     steps: HRF.steps,
                     denoise: HRF.denoise,
                     sampler_name: HRF.useMainSampler ? ui.sampler.sampler_name : 'ddim',
-                    scheduler: HRF.useMainSampler ? ui.sampler.scheduler : 'ddim_uniform',
+                    scheduler: !HRF.useMainSampler ? 'ddim_uniform' : ui.sampler.sigmasType.basic?.scheduler ?? 'ddim_uniform',
                 },
                 { ...ctx_sampler_fix, latent, preview: false },
             ).latent

--- a/library/built-in/CushyDiffusionUI.ts
+++ b/library/built-in/CushyDiffusionUI.ts
@@ -14,7 +14,7 @@ import { ui_advancedPrompt, type UI_advancedPrompt } from './_prefabs/prefab_pro
 import { ui_recursive, type UI_recursive } from './_prefabs/prefab_recursive'
 import { ui_regionalPrompting_v1, type UI_regionalPrompting_v1 } from './_prefabs/prefab_regionalPrompting_v1'
 import { ui_rembg_v1, type UI_rembg_v1 } from './_prefabs/prefab_rembg'
-import { ui_sampler, type UI_Sampler } from './_prefabs/prefab_sampler'
+import { ui_sampler_advanced, type UI_Sampler_Advanced } from './_prefabs/prefab_sampler_advanced'
 import { ui_upscaleWithModel } from './_prefabs/prefab_upscaleWithModel'
 import { ui_watermark_v1, type UI_watermark_v1 } from './_prefabs/prefab_watermark'
 import { ui_customSave, type UI_customSave } from './_prefabs/saveSmall'
@@ -24,7 +24,7 @@ export type CushyDiffusionUI_ = {
     negative: X.XPrompt
     model: UI_Model
     latent: UI_LatentV3
-    sampler: UI_Sampler
+    sampler: UI_Sampler_Advanced
     mask: UI_Mask
     upscaleV2: X.XChoices<{
         highResFix: UI_HighResFix
@@ -62,7 +62,7 @@ export function CushyDiffusionUI(ui: X.Builder): CushyDiffusionUI_ {
         }),
         model: ui_model(),
         latent: ui_latent_v3(),
-        sampler: ui_sampler(),
+        sampler: ui_sampler_advanced(),
         mask: ui_mask(),
         upscaleV2: ui.choicesV2(
             {

--- a/library/built-in/_prefabs/prefab_model.ts
+++ b/library/built-in/_prefabs/prefab_model.ts
@@ -151,6 +151,9 @@ export const run_model = (
 
     let ckpt: HasSingle_MODEL = ckptLoader
     let clip: HasSingle_CLIP = ckptLoader
+    if (ui.ckpt_name.indexOf('sd3') >= 0) {
+        ckpt = graph.ModelSamplingSD3({ model: ckpt, shift: 3 })
+    }
 
     // 2. OPTIONAL CUSTOM VAE
     let vae: _VAE = ckptLoader._VAE

--- a/library/built-in/_prefabs/prefab_model.ts
+++ b/library/built-in/_prefabs/prefab_model.ts
@@ -5,7 +5,24 @@ import { ui_model_pag, type UI_model_pag } from './prefab_model_pag'
 import { ui_model_sag, type UI_model_sag } from './prefab_model_sag'
 
 export type UI_Model = X.XGroup<{
-    ckpt_name: X.XEnum<Enum_CheckpointLoaderSimple_ckpt_name>
+    modelType: X.XChoice<{
+        Diffusion: X.XGroup<{
+            ckpt_name: X.XEnum<Enum_CheckpointLoaderSimple_ckpt_name>
+        }>
+        SD3: X.XGroup<{
+            ckpt_name: X.XEnum<Enum_CheckpointLoaderSimple_ckpt_name>
+            clip1: X.XEnum<Enum_TripleCLIPLoader_clip_name1>
+            clip2: X.XEnum<Enum_TripleCLIPLoader_clip_name2>
+            clip3: X.XEnum<Enum_TripleCLIPLoader_clip_name3>
+        }>
+        FLUX: X.XGroup<{
+            ckpt_name: X.XEnum<Enum_UNETLoader_unet_name>
+            weight_type: X.XEnum<Enum_UNETLoader_weight_dtype>
+            clip1: X.XEnum<Enum_DualCLIPLoader_clip_name1>
+            clip2: X.XEnum<Enum_DualCLIPLoader_clip_name2>
+            type: X.XEnum<Enum_DualCLIPLoader_type>
+        }>
+    }>
     checkpointConfig: X.XOptional<X.XEnum<Enum_CheckpointLoader_config_name>>
     extra: X.XChoices<{
         rescaleCFG: X.XNumber
@@ -57,7 +74,7 @@ export function ui_model(): UI_Model {
                 apply: (w): void => {
                     w.value = {
                         checkpointConfig: undefined,
-                        ckpt_name: 'albedobaseXL_v21.safetensors',
+                        modelType: { Diffusion: { ckpt_name: 'albedobaseXL_v21.safetensors' } },
                         extra: { clipSkip: 2 },
                     }
                 },
@@ -68,15 +85,54 @@ export function ui_model(): UI_Model {
                 apply: (w): void => {
                     w.setValue({
                         checkpointConfig: undefined,
-                        ckpt_name: 'revAnimated_v122.safetensors',
+                        modelType: { Diffusion: { ckpt_name: 'revAnimated_v122.safetensors' } },
                         extra: {},
+                    })
+                },
+            },
+            {
+                icon: 'mdiStar',
+                label: 'SD3',
+                apply: (w): void => {
+                    w.setValue({
+                        checkpointConfig: undefined,
+                        modelType: {
+                            SD3: {
+                                ckpt_name: 'SD3_medium.safetensors',
+                                type: 'sd3',
+                                clip1: 't5xxl_fp18_e4m3fn.safetensors',
+                                clip2: 'clip_l.safetensors',
+                                clip3: 'clip_g.safetensors',
+                            },
+                        },
+                        extra: { vae: undefined },
+                    })
+                },
+            },
+            {
+                icon: 'mdiStar',
+                label: 'FLUX',
+                apply: (w): void => {
+                    w.setValue({
+                        checkpointConfig: undefined,
+                        modelType: {
+                            FLUX: {
+                                ckpt_name: 'flux1-dev.sft',
+                                type: 'flux',
+                                weight_type: 'fp8_e4m3fn',
+                                clip1: 't5xxl_fp16.safetensors',
+                                clip2: 'clip_l.safetensors',
+                            },
+                        },
+                        extra: { vae: 'ae.sft' },
                     })
                 },
             },
         ],
         label: 'Model',
         summary: (ui) => {
-            let out: string = ui.ckpt_name
+            let out: string =
+                ui.modelType.Diffusion?.ckpt_name ?? ui.modelType.SD3?.ckpt_name ?? ui.modelType.FLUX?.ckpt_name ?? 'Empty'
             if (ui.extra.freeU) out += ' + FreeU'
             if (ui.extra.freeUv2) out += ' + FreeUv2'
             if (ui.extra.vae) out += ' + VAE'
@@ -91,9 +147,29 @@ export function ui_model(): UI_Model {
             return out
         },
         items: {
-            ckpt_name: form.enum
-                .Enum_CheckpointLoaderSimple_ckpt_name({ label: 'Checkpoint' })
-                .addRequirements(ckpts.map((x) => ({ type: 'modelCustom', infos: x }))),
+            modelType: form.choice({
+                items: {
+                    Diffusion: form.fields({
+                        ckpt_name: form.enum
+                            .Enum_CheckpointLoaderSimple_ckpt_name({ label: 'Checkpoint' })
+                            .addRequirements(ckpts.map((x) => ({ type: 'modelCustom', infos: x }))),
+                    }),
+                    SD3: form.fields({
+                        ckpt_name: form.enum.Enum_CheckpointLoaderSimple_ckpt_name({ label: 'Checkpoint' }),
+                        clip1: form.enum.Enum_TripleCLIPLoader_clip_name1({ default: 't5xxl_fp16.safetensors' }),
+                        clip2: form.enum.Enum_TripleCLIPLoader_clip_name2({ default: 'clip_l.safetensors' }),
+                        clip3: form.enum.Enum_TripleCLIPLoader_clip_name3({ default: 'clip_g.safetensors' }),
+                    }),
+                    FLUX: form.fields({
+                        ckpt_name: form.enum.Enum_UNETLoader_unet_name({ default: 'flux1-dev.sft' }),
+                        weight_type: form.enum.Enum_UNETLoader_weight_dtype({ label: 'Weight Type', default: 'fp8_e4m3fn' }),
+                        clip1: form.enum.Enum_DualCLIPLoader_clip_name1({ default: 't5xxl_fp16.safetensors' }),
+                        clip2: form.enum.Enum_DualCLIPLoader_clip_name2({ default: 'clip_l.safetensors' }),
+                        type: form.enum.Enum_DualCLIPLoader_type({ default: 'flux' }),
+                    }),
+                },
+                appearance: 'tab',
+            }),
             checkpointConfig: form.enumOpt.Enum_CheckpointLoader_config_name({ label: 'Config' }),
             extra: form.choices({
                 border: false,
@@ -122,43 +198,80 @@ export function ui_model(): UI_Model {
 }
 
 // RUN -----------------------------------------------------------
-export const run_model = (
-    ui: OutputFor<typeof ui_model>,
-): {
+export function run_model(ui: OutputFor<typeof ui_model>): {
     ckpt: _MODEL
     vae: _VAE
     clip: _CLIP
-} => {
+} {
     const run = getCurrentRun()
     const graph = run.nodes
 
     // 1. MODEL
-    let ckptLoader
-    if (ui.checkpointConfig) {
-        ckptLoader = graph.CheckpointLoader({
-            ckpt_name: ui.ckpt_name,
-            config_name: ui.checkpointConfig,
+    let ckpt: _MODEL
+    let clip: _CLIP
+    let vae: _VAE | undefined = undefined
+    if (ui.modelType.Diffusion) {
+        if (ui.checkpointConfig) {
+            const ckptLoader = graph.CheckpointLoader({
+                ckpt_name: ui.modelType.Diffusion.ckpt_name,
+                config_name: ui.checkpointConfig,
+            })
+            ckpt = ckptLoader._MODEL
+            clip = ckptLoader._CLIP
+            vae = ckptLoader._VAE
+        } else if (ui.extra.civitai_ckpt_air) {
+            const ckptLoader = graph.CivitAI$_Checkpoint$_Loader({
+                ckpt_name: ui.modelType.Diffusion.ckpt_name,
+                ckpt_air: ui.extra.civitai_ckpt_air,
+                download_path: 'models\\checkpoints',
+            })
+            ckpt = ckptLoader._MODEL
+            clip = ckptLoader._CLIP
+            vae = ckptLoader._VAE
+        } else {
+            const ckptLoader = graph.CheckpointLoaderSimple({ ckpt_name: ui.modelType.Diffusion.ckpt_name })
+            ckpt = ckptLoader._MODEL
+            clip = ckptLoader._CLIP
+            vae = ckptLoader._VAE
+        }
+    } else if (ui.modelType.SD3) {
+        const ckptLoader = graph.CheckpointLoaderSimple({
+            ckpt_name: ui.modelType.SD3.ckpt_name,
         })
-    } else if (ui.extra.civitai_ckpt_air) {
-        ckptLoader = graph.CivitAI$_Checkpoint$_Loader({
-            ckpt_name: ui.ckpt_name,
-            ckpt_air: ui.extra.civitai_ckpt_air,
-            download_path: 'models\\checkpoints',
+        ckpt = ckptLoader._MODEL
+        vae = ckptLoader._VAE
+        const clipLoader = graph.TripleCLIPLoader({
+            clip_name1: ui.modelType.SD3.clip1,
+            clip_name2: ui.modelType.SD3.clip2,
+            clip_name3: ui.modelType.SD3.clip3,
         })
-    } else {
-        ckptLoader = graph.CheckpointLoaderSimple({ ckpt_name: ui.ckpt_name })
-    }
-
-    let ckpt: HasSingle_MODEL = ckptLoader
-    let clip: HasSingle_CLIP = ckptLoader
-    if (ui.ckpt_name.indexOf('sd3') >= 0) {
+        clip = clipLoader._CLIP
         ckpt = graph.ModelSamplingSD3({ model: ckpt, shift: 3 })
+    } else if (ui.modelType.FLUX) {
+        const ckptLoader = graph.UNETLoader({
+            unet_name: ui.modelType.FLUX.ckpt_name,
+            weight_dtype: ui.modelType.FLUX.weight_type,
+        })
+        ckpt = ckptLoader._MODEL
+        const clipLoader = graph.DualCLIPLoader({
+            clip_name1: ui.modelType.FLUX.clip1,
+            clip_name2: ui.modelType.FLUX.clip2,
+            type: ui.modelType.FLUX.type,
+        })
+        clip = clipLoader._CLIP
+        //Flux requires a vae to be selected
+        if (!ui.extra.vae) {
+            throw new Error('No VAE selected')
+        }
+    } else {
+        throw new Error(`Unknown model type: ${ui.modelType}`)
     }
 
     // 2. OPTIONAL CUSTOM VAE
-    let vae: _VAE = ckptLoader._VAE
     if (ui.extra.vae) vae = graph.VAELoader({ vae_name: ui.extra.vae })
-
+    if (vae === undefined) {
+        throw new Error('No VAE loaded')
+    }
     // 3. OPTIONAL CLIP SKIP
     if (ui.extra.clipSkip) clip = graph.CLIPSetLastLayer({ clip, stop_at_clip_layer: -Math.abs(ui.extra.clipSkip) })
 

--- a/library/built-in/_prefabs/prefab_sampler.ts
+++ b/library/built-in/_prefabs/prefab_sampler.ts
@@ -46,7 +46,7 @@ export function ui_sampler(p?: UiSampleProps): UI_Sampler {
 export type Ctx_sampler = {
     ckpt: _MODEL
     clip: _CLIP
-    latent: HasSingle_LATENT
+    latent: _LATENT
     positive: string | _CONDITIONING
     negative: string | _CONDITIONING
     preview?: boolean

--- a/library/built-in/_prefabs/prefab_sampler_advanced.ts
+++ b/library/built-in/_prefabs/prefab_sampler_advanced.ts
@@ -1,19 +1,72 @@
 import type { Builder, Runtime } from '../../../src/CUSHY'
 import type { OutputFor } from './_prefabs'
 
-// ⏸️ export const shared_samplerName = () => {
-// ⏸️     const form = getCurrentForm()
-// ⏸️     return form.shared(
-// ⏸️         'samplerName',
-// ⏸️         form.enum.Enum_KSampler_sampler_name({
-// ⏸️             label: 'Sampler',
-// ⏸️             default: 'dpmpp_sde',
-// ⏸️         }),
-// ⏸️     )
-// ⏸️ }
+import { run_prompt } from './prefab_prompt'
+
+export type UI_Sampler_Advanced = X.XGroup<{
+    sampler_name: X.XEnum<Enum_KSampler_sampler_name>
+    guidanceType: X.XChoice<{
+        CFG: X.XNumber
+        DualCFG: X.XGroup<{
+            cfg: X.XNumber
+            cfg_conds2_negative: X.XNumber
+            dualCFGPositive2: X.XPrompt
+        }>
+        PerpNeg: X.XGroup<{
+            cfg: X.XNumber
+            negCfg: X.XNumber
+        }>
+    }>
+    sigmasType: X.XChoice<{
+        basic: X.XGroup<{
+            denoise: X.XNumber
+            steps: X.XNumber
+            scheduler: X.XEnum<Enum_KSampler_scheduler>
+        }>
+        AlignYourStep: X.XGroup<{
+            denoise: X.XNumber
+            steps: X.XNumber
+            modelType: X.XEnum<Enum_AlignYourStepsScheduler_model_type>
+        }>
+        karrasCustom: X.XGroup<{
+            steps: X.XNumber
+            sigma_max: X.XNumber
+            sigma_min: X.XNumber
+            rho: X.XNumber
+        }>
+        ExponentialCustom: X.XGroup<{
+            steps: X.XNumber
+            sigma_max: X.XNumber
+            sigma_min: X.XNumber
+        }>
+        polyexponentialCustom: X.XGroup<{
+            steps: X.XNumber
+            sigma_max: X.XNumber
+            sigma_min: X.XNumber
+            rho: X.XNumber
+        }>
+        SDTurbo: X.XGroup<{
+            steps: X.XNumber
+            denoise: X.XNumber
+        }>
+        VPScheduler: X.XGroup<{
+            steps: X.XNumber
+            beta_d: X.XNumber
+            beta_min: X.XNumber
+            eps_s: X.XNumber
+        }>
+    }>
+    seed: X.XSeed
+    textEncoderType: X.XChoice<{
+        CLIP: X.XGroup<{}>
+        SDXL: X.XGroup<{}>
+        SD3: X.XGroup<{}>
+        FLUX: X.XGroup<{}>
+    }>
+}>
 
 // UI -----------------------------------------------------------
-export const ui_sampler_advanced = (p?: {
+export function ui_sampler_advanced(p?: {
     denoise?: number
     steps?: number
     cfg?: number
@@ -21,7 +74,7 @@ export const ui_sampler_advanced = (p?: {
     scheduler?: Enum_KSampler_scheduler
     startCollapsed?: boolean
     sharedSampler?: boolean
-}) => {
+}): UI_Sampler_Advanced {
     const form: X.Builder = getCurrentForm()
     return form.fields(
         {
@@ -37,9 +90,7 @@ export const ui_sampler_advanced = (p?: {
                   }),
             guidanceType: form.choice({
                 items: {
-                    CFG: form.fields({
-                        cfg: form.float({ step: 1, label: 'CFG', min: 0, max: 100, softMax: 10, default: p?.cfg ?? 6 }),
-                    }),
+                    CFG: form.float({ step: 1, label: 'CFG', min: 0, max: 100, softMax: 10, default: p?.cfg ?? 6 }),
                     DualCFG: form.fields({
                         cfg: form.float({ step: 1, label: 'CFG', min: 0, max: 100, softMax: 10, default: p?.cfg ?? 6 }),
                         cfg_conds2_negative: form.float({
@@ -55,7 +106,6 @@ export const ui_sampler_advanced = (p?: {
                             icon: 'mdiAlphabeticalVariant',
                             box: { base: { hue: 150, chroma: 0.05 } },
                         }),
-                        //prompt2: form.prompt({}),
                     }),
                     PerpNeg: form.fields({
                         cfg: form.float({ step: 1, label: 'CFG', min: 0, max: 100, softMax: 10, default: p?.cfg ?? 6 }),
@@ -69,7 +119,7 @@ export const ui_sampler_advanced = (p?: {
                         }),
                     }),
                 },
-                appearance: 'tab',
+                appearance: 'select',
                 default: { CFG: true },
             }),
             // cfg: form.float({ step: 1, label: 'CFG', min: 0, max: 100, softMax: 10, default: p?.cfg ?? 6 }),
@@ -87,12 +137,12 @@ export const ui_sampler_advanced = (p?: {
                         modelType: form.enum.Enum_AlignYourStepsScheduler_model_type({ default: 'SDXL' }),
                     }),
                     karrasCustom: form.auto.KarrasScheduler(),
-                    ExponentialCustom: form.auto.PolyexponentialScheduler(),
+                    ExponentialCustom: form.auto.ExponentialScheduler(),
                     polyexponentialCustom: form.auto.PolyexponentialScheduler(),
                     SDTurbo: form.auto.SDTurboScheduler(),
                     VPScheduler: form.auto.VPScheduler(),
                 },
-                appearance: 'tab',
+                appearance: 'select',
             }),
             seed: form.seed({}),
             textEncoderType: form.choice({
@@ -100,6 +150,8 @@ export const ui_sampler_advanced = (p?: {
                 items: {
                     CLIP: form.group({}),
                     SDXL: form.group({}),
+                    SD3: form.group({}),
+                    FLUX: form.group({}),
                 },
             }),
             // steps: form.int({ step: 10, default: p?.steps ?? 20, label: 'Steps', min: 0, softMax: 100 }),
@@ -125,7 +177,7 @@ export const ui_sampler_advanced = (p?: {
                 let cfg: string = ''
                 if (ui.guidanceType.CFG) {
                     guidance = 'CFG'
-                    cfg = String(ui.guidanceType.CFG.cfg)
+                    cfg = String(ui.guidanceType.CFG)
                 } else if (ui.guidanceType.DualCFG) {
                     guidance = 'Dual CFG'
                     cfg = String(ui.guidanceType.DualCFG.cfg) + '/' + String(ui.guidanceType.DualCFG.cfg_conds2_negative)
@@ -141,6 +193,34 @@ export const ui_sampler_advanced = (p?: {
             box: { base: { hue: 300, chroma: 0.1 } },
             label: 'Sampler',
             startCollapsed: p?.startCollapsed ?? false,
+            presets: [
+                {
+                    label: 'SD3',
+                    icon: 'mdiStar',
+                    apply: (w): void => {
+                        w.value = {
+                            guidanceType: { CFG: 4.5 },
+                            sigmasType: { basic: { denoise: 1, steps: 28, scheduler: 'sgm_uniform' } },
+                            sampler_name: 'dpmpp_2m',
+                            seed: 42,
+                            textEncoderType: { SD3: {} },
+                        }
+                    },
+                },
+                {
+                    label: 'FLUX',
+                    icon: 'mdiStar',
+                    apply: (w): void => {
+                        w.value = {
+                            guidanceType: { CFG: 3.5 },
+                            sigmasType: { basic: { denoise: 1, steps: 28, scheduler: 'simple' } },
+                            sampler_name: 'euler',
+                            seed: 42,
+                            textEncoderType: { FLUX: {} },
+                        }
+                    },
+                },
+            ],
         },
     )
 }
@@ -151,11 +231,11 @@ export type Ctx_sampler_advanced = {
     clip: _CLIP
     latent: _LATENT | HasSingle_LATENT
     positive: string | _CONDITIONING
-    positive2: _CONDITIONING
     negative: string | _CONDITIONING
     width?: number
     height?: number
     preview?: boolean
+    cfg?: number //for flux
     vae: _VAE
 }
 
@@ -163,12 +243,15 @@ export const encodeText = (
     run: Runtime,
     clip: _CLIP,
     text: string,
-    encodingType: 'SDXL' | 'CLIP',
+    encodingType: 'SDXL' | 'CLIP' | 'FLUX' | 'SD3',
+    cfg?: number,
     width?: number,
     height?: number,
 ): _CONDITIONING => {
     const graph = run.nodes
-
+    if (encodingType == 'FLUX' && !cfg) {
+        cfg = 3.5 //default cfg in case not passed
+    }
     const condition =
         encodingType == 'SDXL'
             ? graph.CLIPTextEncodeSDXL({
@@ -180,10 +263,17 @@ export const encodeText = (
                   target_width: width ?? 1024,
                   target_height: height ?? 1024,
               })
-            : graph.CLIPTextEncode({
-                  clip: clip,
-                  text: text,
-              })
+            : encodingType == 'FLUX'
+              ? graph.CLIPTextEncodeFlux({
+                    clip: clip,
+                    clip_l: text,
+                    t5xxl: text,
+                    guidance: cfg,
+                })
+              : graph.CLIPTextEncode({
+                    clip: clip,
+                    text: text,
+                })
 
     return condition
 }
@@ -196,23 +286,56 @@ export const run_sampler_advanced = (
 ): { output: _LATENT; denoised_output: _LATENT } => {
     const graph = run.nodes
     let ckpt = ctx.ckpt
+    const posCondition2string = ui.guidanceType.DualCFG
+        ? run_prompt({ prompt: ui.guidanceType.DualCFG.dualCFGPositive2, printWildcards: true })
+        : undefined
     // flow.output_text(`run_sampler with seed : ${opts.seed}`)
-    const posCondition: _CONDITIONING =
-        typeof ctx.positive === 'string'
-            ? encodeText(run, ctx.clip, ctx.positive, ui.textEncoderType.SDXL ? 'SDXL' : 'CLIP', ctx.width, ctx.height)
-            : ctx.positive
-    const negCondition: _CONDITIONING =
+    let posCondition: _CONDITIONING
+    let negCondition: _CONDITIONING
+    let posCondition2: _CONDITIONING | undefined
+    if (
+        (ui.textEncoderType.CLIP || ui.textEncoderType.SD3) &&
+        typeof ctx.positive === 'string' &&
         typeof ctx.negative === 'string'
-            ? encodeText(run, ctx.clip, ctx.negative, ui.textEncoderType.SDXL ? 'SDXL' : 'CLIP', ctx.width, ctx.height)
-            : ctx.negative
+    ) {
+        posCondition = encodeText(run, ctx.clip, ctx.positive, 'CLIP', ctx.width, ctx.height)
+        negCondition = encodeText(run, ctx.clip, ctx.negative, 'CLIP', ctx.width, ctx.height)
+        if (posCondition2string)
+            posCondition2 = encodeText(run, ctx.clip, posCondition2string.promptIncludingBreaks, 'CLIP', ctx.width, ctx.height)
+        //special negative condition for SD3
+        if (ui.textEncoderType.SD3) {
+            negCondition = graph.ConditioningCombine({
+                conditioning_1: graph.ConditioningSetTimestepRange({
+                    conditioning: graph.ConditioningZeroOut({ conditioning: negCondition }),
+                    start: 0.1,
+                    end: 1.0,
+                }),
+                conditioning_2: graph.ConditioningSetTimestepRange({ conditioning: negCondition, start: 0, end: 0.1 }),
+            })
+            if (posCondition2string) console.log('ERROR: Dual CFG not tested or st up for flux')
+        }
+    } else if (ui.textEncoderType.SDXL && typeof ctx.positive === 'string' && typeof ctx.negative === 'string') {
+        posCondition = encodeText(run, ctx.clip, ctx.positive, 'SDXL', ctx.width, ctx.height)
+        negCondition = encodeText(run, ctx.clip, ctx.negative, 'SDXL', ctx.width, ctx.height)
+        if (posCondition2string)
+            posCondition2 = encodeText(run, ctx.clip, posCondition2string.promptIncludingBreaks, 'SDXL', ctx.width, ctx.height)
+    } else if (ui.textEncoderType.FLUX && typeof ctx.positive === 'string' && typeof ctx.negative === 'string') {
+        posCondition = encodeText(run, ctx.clip, ctx.positive, 'FLUX', ctx.width, ctx.height)
+        negCondition = encodeText(run, ctx.clip, ctx.negative, 'FLUX', ctx.width, ctx.height)
+        if (posCondition2string) console.log('ERROR: Dual CFG not tested or st up for flux')
+    } else {
+        posCondition = ctx.positive as _CONDITIONING
+        negCondition = ctx.negative as _CONDITIONING
+    }
 
     const noise = graph.RandomNoise({ noise_seed: ui.seed }).outputs.NOISE
     let guider: _GUIDER
     if (ui.guidanceType.DualCFG) {
+        if (!posCondition2) throw new Error('Second conditioning not defined')
         guider = graph.DualCFGGuider({
             model: ckpt,
             cond1: posCondition,
-            cond2: ctx.positive2,
+            cond2: posCondition2,
             negative: negCondition,
             cfg_conds: ui.guidanceType.DualCFG.cfg,
             cfg_cond2_negative: ui.guidanceType.DualCFG.cfg_conds2_negative,
@@ -227,12 +350,20 @@ export const run_sampler_advanced = (
             neg_scale: ui.guidanceType.PerpNeg.negCfg,
         })
     else if (ui.guidanceType.CFG)
-        guider = graph.CFGGuider({
-            model: ckpt,
-            positive: posCondition,
-            negative: negCondition,
-            cfg: ui.guidanceType.CFG.cfg,
-        })
+        if (ui.textEncoderType.FLUX) {
+            guider = graph.BasicGuider({
+                model: ckpt,
+                conditioning: posCondition,
+                //atm there isn't really a way to encode negative conditioning on flux that I'm aware of
+            })
+        } else {
+            guider = graph.CFGGuider({
+                model: ckpt,
+                positive: posCondition,
+                negative: negCondition,
+                cfg: ui.guidanceType.CFG,
+            })
+        }
     else throw new Error('❌ Guider type not known')
 
     let sigmas: _SIGMAS

--- a/src/models/MediaImage.ts
+++ b/src/models/MediaImage.ts
@@ -198,6 +198,12 @@ export class MediaImageL {
     onRightClick = (): void => {}
 
     onClick = (ev: MouseEvent): void => {
+        //Delete if not starred
+        if (ev.ctrlKey && ev.shiftKey && ev.altKey && !this.star) {
+            ev.stopPropagation()
+            ev.preventDefault()
+            return void this.delete()
+        }
         if (hasMod(ev)) {
             ev.stopPropagation()
             ev.preventDefault()
@@ -332,6 +338,16 @@ export class MediaImageL {
         if (this.data.tags == null) return []
         // temporary fix to deduplicate tags
         return [...new Set(this.data.tags.split(','))]
+    }
+
+    get star(): number {
+        if (this.data.star == null) return 0
+        return this.data.star
+    }
+
+    set star(n: number) {
+        if (n < 0 || n > 5) throw new Error('star must be between 0 and 5')
+        this.update({ star: n })
     }
 
     /**

--- a/src/panels/Panel_Gallery/GallerySearchControlsUI.tsx
+++ b/src/panels/Panel_Gallery/GallerySearchControlsUI.tsx
@@ -1,5 +1,6 @@
 import { observer } from 'mobx-react-lite'
 
+import { Button } from '../../csuite/button/Button'
 import { SelectUI } from '../../csuite/select/SelectUI'
 
 export const GallerySearchControlsUI = observer(function GallerySearchControlsUI_(p: {}) {
@@ -16,7 +17,12 @@ export const GallerySearchControlsUI = observer(function GallerySearchControlsUI
                     else cushy.galleryFilterPath = next
                 }}
             />
-
+            <Button
+                square
+                icon='mdiStar'
+                active={cushy.galleryFilterStar}
+                onClick={() => (cushy.galleryFilterStar = !cushy.galleryFilterStar)}
+            />
             <input
                 tw='csuite-basic-input my-0.5'
                 placeholder='tags'

--- a/src/state/state.ts
+++ b/src/state/state.ts
@@ -900,6 +900,7 @@ export class STATE {
 
     galleryFilterPath: Maybe<string> = null
     galleryFilterTag: Maybe<string> = null
+    galleryFilterStar: Maybe<boolean> = false
     galleryFilterAppName: Maybe<{ id: CushyAppID; name?: Maybe<string> }> = null
     get imageToDisplay(): MediaImageL[] {
         const conf = this.galleryConf.value
@@ -911,7 +912,7 @@ export class STATE {
                         : query.orderBy('media_image.updatedAt', 'desc')
 
                 x = x.limit(this.galleryConf.value.galleryMaxImages ?? 20).select('media_image.id')
-
+                if (this.galleryFilterStar) x = x.where('media_image.star', '=', this.galleryFilterStar ? 1 : 0)
                 if (this.galleryFilterPath) x = x.where('media_image.path', 'like', '%' + this.galleryFilterPath + '%')
                 if (this.galleryFilterTag) x = x.where('media_image.tags', 'like', '%' + this.galleryFilterTag + '%')
                 if (this.galleryFilterAppName) {


### PR DESCRIPTION
-Added SD3 model support with presets for model/sampler, no documentation or requirements, sorry
-Added Flux model support with presets for model/sampler, no documentation or requirements, sorry
-Switched CushyDiffusion initial sample pass over to advanced sampler, which exposes alternate scheduler options including AlignYourStep (AYS)
-Added a gallery filter to show only starred images
-Added a keyboard/mouse combo to delete images in gallery when Ctrl+Shift+Alt+Click (untested on Linux)